### PR TITLE
使用公钥证书时，签名需要传递公钥证书、支付宝根证书

### DIFF
--- a/alipay/client.go
+++ b/alipay/client.go
@@ -434,6 +434,12 @@ func (a *Client) SystemOauthToken(bm gopay.BodyMap) (aliRsp *SystemOauthTokenRes
 	if err != nil {
 		return nil, err
 	}
+	
+	if a.AppCertSN != gopay.NULL {
+		bm.Set("app_cert_sn", a.AppCertSN)
+		bm.Set("alipay_root_cert_sn", a.AliPayRootCertSN)
+	}
+	
 	var bs []byte
 	if bs, err = systemOauthToken(a.AppId, a.PrivateKeyType, a.PrivateKey, bm, "alipay.system.oauth.token", a.IsProd, a.SignType); err != nil {
 		return nil, err


### PR DESCRIPTION
使用公钥证书的方式，获取accessToken时验签错误修复