### PR TITLE
feat: support higher order func to set mapBody

### DIFF
--- a/body_map.go
+++ b/body_map.go
@@ -16,8 +16,20 @@ var mu sync.RWMutex
 
 // 设置参数
 func (bm BodyMap) Set(key string, value interface{}) {
+
+	var res interface{}
+	switch value.(type) {
+	case func(bm BodyMap):
+		_bm:=make(BodyMap)
+		value.(func(bm BodyMap))(_bm)
+		res=_bm
+		break
+	default:
+		res=value
+	}
+
 	mu.Lock()
-	bm[key] = value
+	bm[key] = res
 	mu.Unlock()
 }
 

--- a/body_map_test.go
+++ b/body_map_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 RS4
+@Author: Weny Xu
+@Date: 2020/12/02 20:20
+*/
+
+package gopay
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBodyMap_Set(t *testing.T) {
+	var b = make(BodyMap)
+	b.Set("test",func(b BodyMap){
+		b.Set("sub", func(b BodyMap) {
+			b.Set("sub-sub","value")
+		})
+	})
+
+	assert.Equal(t, BodyMap{
+		"test": BodyMap{
+			"sub":BodyMap{
+				"sub-sub":"value",
+			},
+		},
+	}, b)
+
+	var b2=make(BodyMap)
+	b2.Set("test","value")
+	assert.Equal(t, BodyMap{
+		"test": "value",
+	}, b2)
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/iGoogle-ink/gopay
 
 go 1.13
 
-require github.com/iGoogle-ink/gotil v1.0.10
+require (
+	github.com/iGoogle-ink/gotil v1.0.10
+	github.com/stretchr/testify v1.6.1
+)


### PR DESCRIPTION
support using higher order func to set BodyMap Value
```go
var b = make(BodyMap)
b.Set("test",func(b BodyMap){
	b.Set("sub", func(b BodyMap) {
		b.Set("sub-sub","value")
	})
})
```
which is equal 
```
{
	"test":{
		"sub":{
			"sub-sub":"value",
		},
	},
}
```