### PR TITLE
支持微信pem证书与p12证书二选一

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/iGoogle-ink/gopay
 
 go 1.13
 
-require github.com/iGoogle-ink/gotil v1.0.10
+require (
+	github.com/iGoogle-ink/gotil v1.0.10
+	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
+)

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,7 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd h1:GGJVjV8waZKRHrgwvtH66z9ZGVurTD1MT0n1Bb+q4aM=
 golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/wechat/client.go
+++ b/wechat/client.go
@@ -2,7 +2,6 @@ package wechat
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -23,8 +22,7 @@ type Client struct {
 	BaseURL     string
 	IsProd      bool
 	DebugSwitch gopay.DebugSwitch
-	certificate tls.Certificate
-	certPool    *x509.CertPool
+	certificate *tls.Certificate
 	mu          sync.RWMutex
 }
 

--- a/wechat/param.go
+++ b/wechat/param.go
@@ -5,11 +5,12 @@ import (
 	"crypto/md5"
 	"crypto/sha256"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/hex"
+	"encoding/pem"
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"golang.org/x/crypto/pkcs12"
 	"hash"
 	"io/ioutil"
 	"strings"
@@ -56,8 +57,7 @@ func (w *Client) AddCertFilePath(certFilePath, keyFilePath, pkcs12FilePath inter
 		return
 	}
 	w.mu.Lock()
-	w.certificate = config.Certificates[0]
-	w.certPool = config.RootCAs
+	w.certificate = &config.Certificates[0]
 	w.mu.Unlock()
 	return
 }
@@ -68,65 +68,74 @@ func (w *Client) AddCertFilePath(certFilePath, keyFilePath, pkcs12FilePath inter
 //	pkcs12FileContent：apiclient_cert.p12 内容
 //	返回err
 func (w *Client) AddCertFileContent(certFileContent, keyFileContent, pkcs12FileContent []byte) (err error) {
-	if err = checkCertFilePath(certFileContent, keyFileContent, pkcs12FileContent); err != nil {
-		return
-	}
-	var config *tls.Config
-	if config, err = w.addCertConfig(certFileContent, keyFileContent, pkcs12FileContent); err != nil {
-		return
-	}
-	w.mu.Lock()
-	w.certificate = config.Certificates[0]
-	w.certPool = config.RootCAs
-	w.mu.Unlock()
-	return
+	return w.AddCertFilePath(certFileContent, keyFileContent, pkcs12FileContent)
+}
+
+// 添加微信pem证书内容
+func (w *Client) AddCertPemFileContent(certFileContent, keyFileContent []byte) (err error) {
+	return w.AddCertFilePath(certFileContent, keyFileContent, nil)
+}
+
+// 添加微信pkcs12证书内容
+func (w *Client) AddCertPkcs12FileContent(pkcs12FileContent []byte) (err error) {
+	return w.AddCertFilePath(nil, nil, pkcs12FileContent)
 }
 
 func (w *Client) addCertConfig(certFile, keyFile, pkcs12File interface{}) (tlsConfig *tls.Config, err error) {
 	if certFile == nil && keyFile == nil && pkcs12File == nil {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if w.certPool != nil {
+		if w.certificate != nil {
 			tlsConfig = &tls.Config{
-				Certificates:       []tls.Certificate{w.certificate},
-				RootCAs:            w.certPool,
+				Certificates:       []tls.Certificate{*w.certificate},
 				InsecureSkipVerify: true,
 			}
 			return tlsConfig, nil
 		}
 	}
 
-	if certFile != nil && keyFile != nil && pkcs12File != nil {
-		var (
-			cert, key, pkcs []byte
-			certificate     tls.Certificate
-		)
+	var (
+		certPem, keyPem []byte
+		certificate     tls.Certificate
+	)
+	if certFile != nil && keyFile != nil {
 		if _, ok := certFile.([]byte); ok {
-			cert = certFile.([]byte)
+			certPem = certFile.([]byte)
 		} else {
-			cert, err = ioutil.ReadFile(certFile.(string))
+			certPem, err = ioutil.ReadFile(certFile.(string))
 		}
 		if _, ok := keyFile.([]byte); ok {
-			key = keyFile.([]byte)
+			keyPem = keyFile.([]byte)
 		} else {
-			key, err = ioutil.ReadFile(keyFile.(string))
-		}
-		if _, ok := pkcs12File.([]byte); ok {
-			pkcs = pkcs12File.([]byte)
-		} else {
-			pkcs, err = ioutil.ReadFile(pkcs12File.(string))
+			keyPem, err = ioutil.ReadFile(keyFile.(string))
 		}
 		if err != nil {
 			return nil, fmt.Errorf("ioutil.ReadFile：%w", err)
 		}
-		pkcsPool := x509.NewCertPool()
-		pkcsPool.AppendCertsFromPEM(pkcs)
-		if certificate, err = tls.X509KeyPair(cert, key); err != nil {
+	} else if pkcs12File != nil {
+		var pfxData []byte
+		if _, ok := pkcs12File.([]byte); ok {
+			pfxData = pkcs12File.([]byte)
+		} else {
+			if pfxData, err = ioutil.ReadFile(pkcs12File.(string)); err != nil {
+				return nil, fmt.Errorf("ioutil.ReadFile：%w", err)
+			}
+		}
+		blocks, err := pkcs12.ToPEM(pfxData, w.MchId)
+		if err != nil {
+			return nil, fmt.Errorf("pkcs12.ToPEM：%w", err)
+		}
+		for _, b := range blocks {
+			keyPem = append(keyPem, pem.EncodeToMemory(b)...)
+		}
+		certPem = keyPem
+	}
+	if certPem != nil && keyPem != nil {
+		if certificate, err = tls.X509KeyPair(certPem, keyPem); err != nil {
 			return nil, fmt.Errorf("tls.LoadX509KeyPair：%w", err)
 		}
 		tlsConfig = &tls.Config{
 			Certificates:       []tls.Certificate{certificate},
-			RootCAs:            pkcsPool,
 			InsecureSkipVerify: true,
 		}
 		return tlsConfig, nil
@@ -135,12 +144,11 @@ func (w *Client) addCertConfig(certFile, keyFile, pkcs12File interface{}) (tlsCo
 }
 
 func checkCertFilePath(certFilePath, keyFilePath, pkcs12FilePath interface{}) error {
-	if certFilePath != nil && keyFilePath != nil && pkcs12FilePath != nil {
-		files := map[string]interface{}{
-			"certFilePath":   certFilePath,
-			"keyFilePath":    keyFilePath,
-			"pkcs12FilePath": pkcs12FilePath,
-		}
+	if certFilePath == nil && keyFilePath == nil && pkcs12FilePath == nil {
+		return nil
+	}
+	if certFilePath != nil && keyFilePath != nil {
+		files := map[string]interface{}{"certFilePath": certFilePath, "keyFilePath": keyFilePath}
 		for varName, v := range files {
 			switch v.(type) {
 			case string:
@@ -156,11 +164,23 @@ func checkCertFilePath(certFilePath, keyFilePath, pkcs12FilePath interface{}) er
 			}
 		}
 		return nil
+	} else if pkcs12FilePath != nil {
+		switch pkcs12FilePath.(type) {
+		case string:
+			if pkcs12FilePath.(string) == gotil.NULL {
+				return errors.New("pkcs12FilePath is empty")
+			}
+		case []byte:
+			if len(pkcs12FilePath.([]byte)) == 0 {
+				return errors.New("pkcs12FilePath is empty")
+			}
+		default:
+			return errors.New("pkcs12FilePath type error")
+		}
+		return nil
+	} else {
+		return errors.New("certFilePath keyFilePath must all nil or all not nil")
 	}
-	if !(certFilePath == nil && keyFilePath == nil && pkcs12FilePath == nil) {
-		return errors.New("cert paths must all nil or all not nil")
-	}
-	return nil
 }
 
 // 获取微信支付正式环境Sign值


### PR DESCRIPTION
1. 根据 [微信证书使用文档](https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=4_3)，支持微信pem证书与p12证书二选一。P12 证书则是转成 PEM，[官方示例代码](https://github.com/golang/crypto/blob/master/pkcs12/pkcs12_test.go#L34)
2. 删除无用字段和新增两个添加证书内容的方法

已经通过 refund 方法自测过了，能正常退款。

