### PR TITLE
重构支付宝client的 PostAliPayAPISelf() 方法，使其更加灵活

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ $ go get github.com/iGoogle-ink/gopay
 
 ```go
 import (
-"fmt"
+    "fmt"
 
-"github.com/iGoogle-ink/gopay"
+    "github.com/iGoogle-ink/gopay"
 )
 
 func main() {
-xlog.Debug("GoPay Version: ", gopay.Version)
+    xlog.Debug("GoPay Version: ", gopay.Version)
 }
 ```
 
@@ -201,7 +201,7 @@ QQ群：
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay/wechat/v3"
+	"github.com/iGoogle-ink/gopay/wechat/v3"
 )
 
 // NewClientV3 初始化微信客户端 V3
@@ -212,8 +212,8 @@ import (
 //	pkContent：私钥 apiclient_key.pem 读取后的内容
 client, err = NewClientV3(Appid, MchId, SerialNo, ApiV3Key, PKContent)
 if err != nil {
-xlog.Error(err)
-return
+    xlog.Error(err)
+    return
 }
 
 // 自动验签
@@ -234,7 +234,7 @@ client.DebugSwitch = gopay.DebugOff
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay/wechat"
+	"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // 初始化微信客户端
@@ -293,17 +293,17 @@ client.DebugSwitch = gopay.DebugOn
 
 // 设置支付宝请求 公共参数
 //    注意：具体设置哪些参数，根据不同的方法而不同，此处列举出所有设置参数
-client.SetLocation(). // 设置时区，不设置或出错均为默认服务器时间
-SetPrivateKeyType().  // 设置 支付宝 私钥类型，alipay.PKCS1 或 alipay.PKCS8，默认 PKCS1
-SetAliPayRootCertSN().                  // 设置支付宝根证书SN，通过 alipay.GetRootCertSN() 获取
-SetAppCertSN().                         // 设置应用公钥证书SN，通过 alipay.GetCertSN() 获取
-SetAliPayPublicCertSN().                // 设置支付宝公钥证书SN，通过 alipay.GetCertSN() 获取
-SetCharset("utf-8"). // 设置字符编码，不设置默认 utf-8
-SetSignType(alipay.RSA2).               // 设置签名类型，不设置默认 RSA2
-SetReturnUrl("https://www.gopay.ink").  // 设置返回URL
-SetNotifyUrl("https://www.gopay.ink").  // 设置异步通知URL
-SetAppAuthToken().                      // 设置第三方应用授权
-SetAuthToken()                          // 设置个人信息授权
+client.SetLocation().                       // 设置时区，不设置或出错均为默认服务器时间
+    SetPrivateKeyType().                    // 设置 支付宝 私钥类型，alipay.PKCS1 或 alipay.PKCS8，默认 PKCS1
+    SetAliPayRootCertSN().                  // 设置支付宝根证书SN，通过 alipay.GetRootCertSN() 获取
+    SetAppCertSN().                         // 设置应用公钥证书SN，通过 alipay.GetCertSN() 获取
+    SetAliPayPublicCertSN().                // 设置支付宝公钥证书SN，通过 alipay.GetCertSN() 获取
+    SetCharset("utf-8").                    // 设置字符编码，不设置默认 utf-8
+    SetSignType(alipay.RSA2).               // 设置签名类型，不设置默认 RSA2
+    SetReturnUrl("https://www.gopay.ink").  // 设置返回URL
+    SetNotifyUrl("https://www.gopay.ink").  // 设置异步通知URL
+    SetAppAuthToken().                      // 设置第三方应用授权
+    SetAuthToken()                          // 设置个人信息授权
 
 // 证书路径
 err := client.SetCertSnByPath("appCertPublicKey.crt", "alipayRootCert.crt", "alipayCertPublicKey_RSA2.crt")
@@ -320,28 +320,28 @@ err := client.SetCertSnByContent("appCertPublicKey bytes", "alipayRootCert bytes
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay/pkg/util"
-"github.com/iGoogle-ink/gopay/wechat"
+    "github.com/iGoogle-ink/gopay/pkg/util"
+	"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // 初始化 BodyMap
 bm := make(gopay.BodyMap)
 bm.Set("nonce_str", util.GetRandomString(32)).
-Set("body", "H5支付").
-Set("out_trade_no", number).
-Set("total_fee", 1).
-Set("spbill_create_ip", "127.0.0.1").
-Set("notify_url", "http://www.gopay.ink").
-Set("trade_type", TradeType_H5).
-Set("device_info", "WEB").
-Set("sign_type", SignType_MD5).
-SetBodyMap("scene_info", func (bm gopay.BodyMap) {
-bm.SetBodyMap("h5_info", func (bm gopay.BodyMap) {
-bm.Set("type", "Wap")
-bm.Set("wap_url", "http://www.gopay.ink")
-bm.Set("wap_name", "H5测试支付")
-})
-}) /*.Set("openid", "o0Df70H2Q0fY8JXh1aFPIRyOBgu8")*/
+    Set("body", "H5支付").
+    Set("out_trade_no", number).
+    Set("total_fee", 1).
+    Set("spbill_create_ip", "127.0.0.1").
+    Set("notify_url", "http://www.gopay.ink").
+    Set("trade_type", TradeType_H5).
+    Set("device_info", "WEB").
+    Set("sign_type", SignType_MD5).
+    SetBodyMap("scene_info", func(bm gopay.BodyMap) {
+        bm.SetBodyMap("h5_info", func(bm gopay.BodyMap) {
+            bm.Set("type", "Wap")
+            bm.Set("wap_url", "http://www.gopay.ink")
+            bm.Set("wap_name", "H5测试支付")
+        })
+    }) /*.Set("openid", "o0Df70H2Q0fY8JXh1aFPIRyOBgu8")*/
 
 // 参数 sign ，可单独生成赋值到BodyMap中；也可不传sign参数，client内部会自动获取
 // 如需单独赋值 sign 参数，需通过下面方法，最后获取sign值并在最后赋值此参数
@@ -358,10 +358,10 @@ bm.Set("sign", sign)
 // 初始化 BodyMap
 bm := make(gopay.BodyMap)
 bm.Set("subject", "手机网站测试支付").
-Set("out_trade_no", "GZ201909081743431443").
-Set("quit_url", "https://www.gopay.ink").
-Set("total_amount", "100.00").
-Set("product_code", "QUICK_WAP_WAY")
+    Set("out_trade_no", "GZ201909081743431443").
+    Set("quit_url", "https://www.gopay.ink").
+    Set("total_amount", "100.00").
+    Set("product_code", "QUICK_WAP_WAY")
 ```
 
 ## 3、client 方法调用
@@ -432,12 +432,12 @@ APP支付官方文档：[APP端调起支付的参数列表文档](https://pay.we
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay/wechat"
+	"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // ====微信小程序 paySign====
 timeStamp := strconv.FormatInt(time.Now().Unix(), 10)
-packages := "prepay_id=" + wxRsp.PrepayId // 此处的 wxRsp.PrepayId ,统一下单成功后得到
+packages := "prepay_id=" + wxRsp.PrepayId   // 此处的 wxRsp.PrepayId ,统一下单成功后得到
 // 获取微信小程序支付的 paySign
 //    appId：AppID
 //    nonceStr：随机字符串
@@ -462,7 +462,7 @@ paySign := wechat.GetAppPaySign(appid, partnerid, wxRsp.NonceStr, wxRsp.PrepayId
 
 // ====微信内H5支付 paySign====
 timeStamp := strconv.FormatInt(time.Now().Unix(), 10)
-packages := "prepay_id=" + wxRsp.PrepayId // 此处的 wxRsp.PrepayId ,统一下单成功后得到
+packages := "prepay_id=" + wxRsp.PrepayId   // 此处的 wxRsp.PrepayId ,统一下单成功后得到
 // 获取微信内H5支付 paySign
 //    appId：AppID
 //    nonceStr：随机字符串
@@ -487,8 +487,8 @@ paySign := wechat.GetH5PaySign(AppID, wxRsp.NonceStr, packages, wechat.SignType_
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay"
-"github.com/iGoogle-ink/gopay/wechat"
+	"github.com/iGoogle-ink/gopay"
+	"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // ====同步返回参数验签Sign====
@@ -522,7 +522,7 @@ ok, err := wechat.VerifySign(apiKey, wechat.SignType_MD5, notifyReq)
 //    返回参数 notifyReq：通知的参数
 //    返回参数 err：错误信息
 notifyReq, err := wechat.ParseNotifyToBodyMap(c.Request)
-或
+ 或
 notifyReq, err := wechat.ParseRefundNotify(c.Request)
 
 // ==解密退款异步通知的加密参数 req_info ==
@@ -533,8 +533,8 @@ rsp := new(wechat.NotifyResponse) // 回复微信的数据
 rsp.ReturnCode = gopay.SUCCESS
 rsp.ReturnMsg = gopay.OK
 
-return c.String(http.StatusOK, rsp.ToXmlString()) // 此写法是 echo 框架返回微信的写法
-c.String(http.StatusOK, "%s", rsp.ToXmlString()) // 此写法是 gin 框架返回微信的写法
+return c.String(http.StatusOK, rsp.ToXmlString())   // 此写法是 echo 框架返回微信的写法
+c.String(http.StatusOK, "%s", rsp.ToXmlString())    // 此写法是 gin 框架返回微信的写法
 ```
 
 * #### 支付宝
@@ -545,7 +545,7 @@ c.String(http.StatusOK, "%s", rsp.ToXmlString()) // 此写法是 gin 框架返�
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay/alipay"
+	"github.com/iGoogle-ink/gopay/alipay"
 )
 
 // ====同步返回参数验签Sign====
@@ -566,8 +566,8 @@ ok, err := alipay.VerifySyncSignWithCert(aliPayPublicKeyCert, aliRsp.SignData, a
 //    req：*http.Request
 //    返回参数 notifyReq：通知的参数
 //    返回参数 err：错误信息
-notifyReq, err = alipay.ParseNotifyToBodyMap(c.Request()) // c.Request()是 echo 框架的获取
-或
+notifyReq, err = alipay.ParseNotifyToBodyMap(c.Request())     // c.Request()是 echo 框架的获取
+ 或
 notifyReq, err = alipay.ParseNotifyByURLValues()
 
 // 验签操作
@@ -578,8 +578,8 @@ ok, err = alipay.VerifySignWithCert("alipayCertPublicKey_RSA2.crt", notifyReq)
 // ==异步通知，返回支付宝平台的信息==
 //    文档：https://opendocs.alipay.com/open/203/105286
 //    程序执行完后必须打印输出“success”（不包含引号）。如果商户反馈给支付宝的字符不是success这7个字符，支付宝服务器会不断重发通知，直到超过24小时22分钟。一般情况下，25小时以内完成8次通知（通知的间隔频率一般是：4m,10m,10m,1h,2h,6h,15h）
-return c.String(http.StatusOK, "success") // 此写法是 echo 框架返回支付宝的写法
-c.String(http.StatusOK, "%s", "success") // 此写法是 gin 框架返回支付宝的写法
+return c.String(http.StatusOK, "success")   // 此写法是 echo 框架返回支付宝的写法
+c.String(http.StatusOK, "%s", "success")    // 此写法是 gin 框架返回支付宝的写法
 ```
 
 ## 6、微信、支付宝 公共API（仅部分说明）
@@ -594,7 +594,7 @@ button按钮获取手机号码：[button组件文档](https://developers.weixin.
 
 ```go
 import (
-"github.com/iGoogle-ink/gopay/wechat"
+	"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // 获取微信小程序用户的OpenId、SessionKey、UnionId
@@ -630,15 +630,15 @@ xlog.Debug(*userInfo)
 data := "Kf3TdPbzEmhWMuPKtlKxIWDkijhn402w1bxoHL4kLdcKr6jT1jNcIhvDJfjXmJcgDWLjmBiIGJ5acUuSvxLws3WgAkERmtTuiCG10CKLsJiR+AXVk7B2TUQzsq88YVilDz/YAN3647REE7glGmeBPfvUmdbfDzhL9BzvEiuRhABuCYyTMz4iaM8hFjbLB1caaeoOlykYAFMWC5pZi9P8uw=="
 iv := "Cds8j3VYoGvnTp1BrjXdJg=="
 session := "lyY4HPQbaOYzZdG+JcYK9w=="
-
+    
 // 解密开放数据到 BodyMap
 //    encryptedData:包括敏感数据在内的完整用户信息的加密数据
 //    iv:加密算法的初始向量
 //    sessionKey:会话密钥
 bm, err := wechat.DecryptOpenDataToBodyMap(data, iv, session)
 if err != nil {
-xlog.Debug("err:", err)
-return
+     xlog.Debug("err:", err)
+     return
 }
 xlog.Debug("WeChatUserPhone:", bm)
 ```
@@ -649,12 +649,10 @@ xlog.Debug("WeChatUserPhone:", bm)
 
 获取用户手机号文档：[获取用户手机号](https://opendocs.alipay.com/mini/api/getphonenumber)
 
-支付宝加解密文档：[AES配置文档](https://opendocs.alipay.com/mini/introduce/aes)
-，[AES加解密文档](https://opendocs.alipay.com/open/common/104567)
-
+支付宝加解密文档：[AES配置文档](https://opendocs.alipay.com/mini/introduce/aes) ，[AES加解密文档](https://opendocs.alipay.com/open/common/104567)
 ```go
 import (
-"github.com/iGoogle-ink/gopay/alipay"
+	"github.com/iGoogle-ink/gopay/alipay"
 )
 
 // 换取授权访问令牌（默认使用utf-8，RSA2）

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ $ go get github.com/iGoogle-ink/gopay
 
 * #### 查看 GoPay 版本
     * [版本更新记录](https://github.com/iGoogle-ink/gopay/blob/main/release_note.txt)
+
 ```go
 import (
-    "fmt"
+"fmt"
 
-    "github.com/iGoogle-ink/gopay"
+"github.com/iGoogle-ink/gopay"
 )
 
 func main() {
-    xlog.Debug("GoPay Version: ", gopay.Version)
+xlog.Debug("GoPay Version: ", gopay.Version)
 }
 ```
 
@@ -126,7 +127,7 @@ func main() {
 
 ### 支付宝支付API
 
-> #### 因支付宝接口太多，如没实现的接口，还请开发者自行调用client.PostAliPayAPISelf()方法实现！
+> #### 因支付宝接口太多，如没实现的接口，还请开发者自行调用client.PostAliPayAPISelf()方法实现！请参考 client_test.go 内的 TestClient_PostAliPayAPISelf() 方法
 
 * 支付宝接口自行实现方法：client.PostAliPayAPISelf()
 * 手机网站支付接口2.0（手机网站支付）：client.TradeWapPay()
@@ -200,7 +201,7 @@ QQ群：
 
 ```go
 import (
-	"github.com/iGoogle-ink/gopay/wechat/v3"
+"github.com/iGoogle-ink/gopay/wechat/v3"
 )
 
 // NewClientV3 初始化微信客户端 V3
@@ -211,8 +212,8 @@ import (
 //	pkContent：私钥 apiclient_key.pem 读取后的内容
 client, err = NewClientV3(Appid, MchId, SerialNo, ApiV3Key, PKContent)
 if err != nil {
-    xlog.Error(err)
-    return
+xlog.Error(err)
+return
 }
 
 // 自动验签
@@ -233,7 +234,7 @@ client.DebugSwitch = gopay.DebugOff
 
 ```go
 import (
-	"github.com/iGoogle-ink/gopay/wechat"
+"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // 初始化微信客户端
@@ -292,17 +293,17 @@ client.DebugSwitch = gopay.DebugOn
 
 // 设置支付宝请求 公共参数
 //    注意：具体设置哪些参数，根据不同的方法而不同，此处列举出所有设置参数
-client.SetLocation().                       // 设置时区，不设置或出错均为默认服务器时间
-    SetPrivateKeyType().                    // 设置 支付宝 私钥类型，alipay.PKCS1 或 alipay.PKCS8，默认 PKCS1
-    SetAliPayRootCertSN().                  // 设置支付宝根证书SN，通过 alipay.GetRootCertSN() 获取
-    SetAppCertSN().                         // 设置应用公钥证书SN，通过 alipay.GetCertSN() 获取
-    SetAliPayPublicCertSN().                // 设置支付宝公钥证书SN，通过 alipay.GetCertSN() 获取
-    SetCharset("utf-8").                    // 设置字符编码，不设置默认 utf-8
-    SetSignType(alipay.RSA2).               // 设置签名类型，不设置默认 RSA2
-    SetReturnUrl("https://www.gopay.ink").  // 设置返回URL
-    SetNotifyUrl("https://www.gopay.ink").  // 设置异步通知URL
-    SetAppAuthToken().                      // 设置第三方应用授权
-    SetAuthToken()                          // 设置个人信息授权
+client.SetLocation(). // 设置时区，不设置或出错均为默认服务器时间
+SetPrivateKeyType().  // 设置 支付宝 私钥类型，alipay.PKCS1 或 alipay.PKCS8，默认 PKCS1
+SetAliPayRootCertSN().                  // 设置支付宝根证书SN，通过 alipay.GetRootCertSN() 获取
+SetAppCertSN().                         // 设置应用公钥证书SN，通过 alipay.GetCertSN() 获取
+SetAliPayPublicCertSN().                // 设置支付宝公钥证书SN，通过 alipay.GetCertSN() 获取
+SetCharset("utf-8"). // 设置字符编码，不设置默认 utf-8
+SetSignType(alipay.RSA2).               // 设置签名类型，不设置默认 RSA2
+SetReturnUrl("https://www.gopay.ink").  // 设置返回URL
+SetNotifyUrl("https://www.gopay.ink").  // 设置异步通知URL
+SetAppAuthToken().                      // 设置第三方应用授权
+SetAuthToken()                          // 设置个人信息授权
 
 // 证书路径
 err := client.SetCertSnByPath("appCertPublicKey.crt", "alipayRootCert.crt", "alipayCertPublicKey_RSA2.crt")
@@ -319,28 +320,28 @@ err := client.SetCertSnByContent("appCertPublicKey bytes", "alipayRootCert bytes
 
 ```go
 import (
-    "github.com/iGoogle-ink/gopay/pkg/util"
-	"github.com/iGoogle-ink/gopay/wechat"
+"github.com/iGoogle-ink/gopay/pkg/util"
+"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // 初始化 BodyMap
 bm := make(gopay.BodyMap)
 bm.Set("nonce_str", util.GetRandomString(32)).
-    Set("body", "H5支付").
-    Set("out_trade_no", number).
-    Set("total_fee", 1).
-    Set("spbill_create_ip", "127.0.0.1").
-    Set("notify_url", "http://www.gopay.ink").
-    Set("trade_type", TradeType_H5).
-    Set("device_info", "WEB").
-    Set("sign_type", SignType_MD5).
-    SetBodyMap("scene_info", func(bm gopay.BodyMap) {
-        bm.SetBodyMap("h5_info", func(bm gopay.BodyMap) {
-            bm.Set("type", "Wap")
-            bm.Set("wap_url", "http://www.gopay.ink")
-            bm.Set("wap_name", "H5测试支付")
-        })
-    }) /*.Set("openid", "o0Df70H2Q0fY8JXh1aFPIRyOBgu8")*/
+Set("body", "H5支付").
+Set("out_trade_no", number).
+Set("total_fee", 1).
+Set("spbill_create_ip", "127.0.0.1").
+Set("notify_url", "http://www.gopay.ink").
+Set("trade_type", TradeType_H5).
+Set("device_info", "WEB").
+Set("sign_type", SignType_MD5).
+SetBodyMap("scene_info", func (bm gopay.BodyMap) {
+bm.SetBodyMap("h5_info", func (bm gopay.BodyMap) {
+bm.Set("type", "Wap")
+bm.Set("wap_url", "http://www.gopay.ink")
+bm.Set("wap_name", "H5测试支付")
+})
+}) /*.Set("openid", "o0Df70H2Q0fY8JXh1aFPIRyOBgu8")*/
 
 // 参数 sign ，可单独生成赋值到BodyMap中；也可不传sign参数，client内部会自动获取
 // 如需单独赋值 sign 参数，需通过下面方法，最后获取sign值并在最后赋值此参数
@@ -357,10 +358,10 @@ bm.Set("sign", sign)
 // 初始化 BodyMap
 bm := make(gopay.BodyMap)
 bm.Set("subject", "手机网站测试支付").
-    Set("out_trade_no", "GZ201909081743431443").
-    Set("quit_url", "https://www.gopay.ink").
-    Set("total_amount", "100.00").
-    Set("product_code", "QUICK_WAP_WAY")
+Set("out_trade_no", "GZ201909081743431443").
+Set("quit_url", "https://www.gopay.ink").
+Set("total_amount", "100.00").
+Set("product_code", "QUICK_WAP_WAY")
 ```
 
 ## 3、client 方法调用
@@ -431,12 +432,12 @@ APP支付官方文档：[APP端调起支付的参数列表文档](https://pay.we
 
 ```go
 import (
-	"github.com/iGoogle-ink/gopay/wechat"
+"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // ====微信小程序 paySign====
 timeStamp := strconv.FormatInt(time.Now().Unix(), 10)
-packages := "prepay_id=" + wxRsp.PrepayId   // 此处的 wxRsp.PrepayId ,统一下单成功后得到
+packages := "prepay_id=" + wxRsp.PrepayId // 此处的 wxRsp.PrepayId ,统一下单成功后得到
 // 获取微信小程序支付的 paySign
 //    appId：AppID
 //    nonceStr：随机字符串
@@ -461,7 +462,7 @@ paySign := wechat.GetAppPaySign(appid, partnerid, wxRsp.NonceStr, wxRsp.PrepayId
 
 // ====微信内H5支付 paySign====
 timeStamp := strconv.FormatInt(time.Now().Unix(), 10)
-packages := "prepay_id=" + wxRsp.PrepayId   // 此处的 wxRsp.PrepayId ,统一下单成功后得到
+packages := "prepay_id=" + wxRsp.PrepayId // 此处的 wxRsp.PrepayId ,统一下单成功后得到
 // 获取微信内H5支付 paySign
 //    appId：AppID
 //    nonceStr：随机字符串
@@ -486,8 +487,8 @@ paySign := wechat.GetH5PaySign(AppID, wxRsp.NonceStr, packages, wechat.SignType_
 
 ```go
 import (
-	"github.com/iGoogle-ink/gopay"
-	"github.com/iGoogle-ink/gopay/wechat"
+"github.com/iGoogle-ink/gopay"
+"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // ====同步返回参数验签Sign====
@@ -521,7 +522,7 @@ ok, err := wechat.VerifySign(apiKey, wechat.SignType_MD5, notifyReq)
 //    返回参数 notifyReq：通知的参数
 //    返回参数 err：错误信息
 notifyReq, err := wechat.ParseNotifyToBodyMap(c.Request)
- 或
+或
 notifyReq, err := wechat.ParseRefundNotify(c.Request)
 
 // ==解密退款异步通知的加密参数 req_info ==
@@ -532,8 +533,8 @@ rsp := new(wechat.NotifyResponse) // 回复微信的数据
 rsp.ReturnCode = gopay.SUCCESS
 rsp.ReturnMsg = gopay.OK
 
-return c.String(http.StatusOK, rsp.ToXmlString())   // 此写法是 echo 框架返回微信的写法
-c.String(http.StatusOK, "%s", rsp.ToXmlString())    // 此写法是 gin 框架返回微信的写法
+return c.String(http.StatusOK, rsp.ToXmlString()) // 此写法是 echo 框架返回微信的写法
+c.String(http.StatusOK, "%s", rsp.ToXmlString()) // 此写法是 gin 框架返回微信的写法
 ```
 
 * #### 支付宝
@@ -544,7 +545,7 @@ c.String(http.StatusOK, "%s", rsp.ToXmlString())    // 此写法是 gin 框架�
 
 ```go
 import (
-	"github.com/iGoogle-ink/gopay/alipay"
+"github.com/iGoogle-ink/gopay/alipay"
 )
 
 // ====同步返回参数验签Sign====
@@ -560,14 +561,13 @@ ok, err := alipay.VerifySyncSign(aliPayPublicKey, aliRsp.SignData, aliRsp.Sign)
 //    aliPayPublicKeyCert：支付宝公钥证书存放路径 alipayCertPublicKey_RSA2.crt 或文件内容[]byte
 ok, err := alipay.VerifySyncSignWithCert(aliPayPublicKeyCert, aliRsp.SignData, aliRsp.Sign)
 
-
 // ====异步通知参数解析和验签Sign====
 // 解析异步通知的参数
 //    req：*http.Request
 //    返回参数 notifyReq：通知的参数
 //    返回参数 err：错误信息
-notifyReq, err = alipay.ParseNotifyToBodyMap(c.Request())     // c.Request()是 echo 框架的获取
- 或
+notifyReq, err = alipay.ParseNotifyToBodyMap(c.Request()) // c.Request()是 echo 框架的获取
+或
 notifyReq, err = alipay.ParseNotifyByURLValues()
 
 // 验签操作
@@ -578,8 +578,8 @@ ok, err = alipay.VerifySignWithCert("alipayCertPublicKey_RSA2.crt", notifyReq)
 // ==异步通知，返回支付宝平台的信息==
 //    文档：https://opendocs.alipay.com/open/203/105286
 //    程序执行完后必须打印输出“success”（不包含引号）。如果商户反馈给支付宝的字符不是success这7个字符，支付宝服务器会不断重发通知，直到超过24小时22分钟。一般情况下，25小时以内完成8次通知（通知的间隔频率一般是：4m,10m,10m,1h,2h,6h,15h）
-return c.String(http.StatusOK, "success")   // 此写法是 echo 框架返回支付宝的写法
-c.String(http.StatusOK, "%s", "success")    // 此写法是 gin 框架返回支付宝的写法
+return c.String(http.StatusOK, "success") // 此写法是 echo 框架返回支付宝的写法
+c.String(http.StatusOK, "%s", "success") // 此写法是 gin 框架返回支付宝的写法
 ```
 
 ## 6、微信、支付宝 公共API（仅部分说明）
@@ -594,7 +594,7 @@ button按钮获取手机号码：[button组件文档](https://developers.weixin.
 
 ```go
 import (
-	"github.com/iGoogle-ink/gopay/wechat"
+"github.com/iGoogle-ink/gopay/wechat"
 )
 
 // 获取微信小程序用户的OpenId、SessionKey、UnionId
@@ -630,15 +630,15 @@ xlog.Debug(*userInfo)
 data := "Kf3TdPbzEmhWMuPKtlKxIWDkijhn402w1bxoHL4kLdcKr6jT1jNcIhvDJfjXmJcgDWLjmBiIGJ5acUuSvxLws3WgAkERmtTuiCG10CKLsJiR+AXVk7B2TUQzsq88YVilDz/YAN3647REE7glGmeBPfvUmdbfDzhL9BzvEiuRhABuCYyTMz4iaM8hFjbLB1caaeoOlykYAFMWC5pZi9P8uw=="
 iv := "Cds8j3VYoGvnTp1BrjXdJg=="
 session := "lyY4HPQbaOYzZdG+JcYK9w=="
-    
+
 // 解密开放数据到 BodyMap
 //    encryptedData:包括敏感数据在内的完整用户信息的加密数据
 //    iv:加密算法的初始向量
 //    sessionKey:会话密钥
 bm, err := wechat.DecryptOpenDataToBodyMap(data, iv, session)
 if err != nil {
-     xlog.Debug("err:", err)
-     return
+xlog.Debug("err:", err)
+return
 }
 xlog.Debug("WeChatUserPhone:", bm)
 ```
@@ -649,10 +649,12 @@ xlog.Debug("WeChatUserPhone:", bm)
 
 获取用户手机号文档：[获取用户手机号](https://opendocs.alipay.com/mini/api/getphonenumber)
 
-支付宝加解密文档：[AES配置文档](https://opendocs.alipay.com/mini/introduce/aes) ，[AES加解密文档](https://opendocs.alipay.com/open/common/104567)
+支付宝加解密文档：[AES配置文档](https://opendocs.alipay.com/mini/introduce/aes)
+，[AES加解密文档](https://opendocs.alipay.com/open/common/104567)
+
 ```go
 import (
-	"github.com/iGoogle-ink/gopay/alipay"
+"github.com/iGoogle-ink/gopay/alipay"
 )
 
 // 换取授权访问令牌（默认使用utf-8，RSA2）

--- a/alipay/client.go
+++ b/alipay/client.go
@@ -125,33 +125,24 @@ func (a *Client) doAliPaySelf(bm gopay.BodyMap, method string) (bs []byte, err e
 		xlog.Debugf("Alipay_Request: %s", req)
 	}
 	param := FormatURLParam(pubBody)
-	switch method {
-	case "alipay.trade.app.pay":
-		return []byte(param), nil
-	case "alipay.trade.wap.pay", "alipay.trade.page.pay", "alipay.user.certify.open.certify":
-		if !a.IsProd {
-			return []byte(sandboxBaseUrl + "?" + param), nil
-		}
-		return []byte(baseUrl + "?" + param), nil
-	default:
-		httpClient := xhttp.NewClient()
-		if a.IsProd {
-			url = baseUrlUtf8
-		} else {
-			url = sandboxBaseUrlUtf8
-		}
-		res, bs, errs := httpClient.Type(xhttp.TypeForm).Post(url).SendString(param).EndBytes()
-		if len(errs) > 0 {
-			return nil, errs[0]
-		}
-		if a.DebugSwitch == gopay.DebugOn {
-			xlog.Debugf("Alipay_Response: %s%d %s%s", xlog.Red, res.StatusCode, xlog.Reset, string(bs))
-		}
-		if res.StatusCode != 200 {
-			return nil, fmt.Errorf("HTTP Request Error, StatusCode = %d", res.StatusCode)
-		}
-		return bs, nil
+
+	httpClient := xhttp.NewClient()
+	if a.IsProd {
+		url = baseUrlUtf8
+	} else {
+		url = sandboxBaseUrlUtf8
 	}
+	res, bs, errs := httpClient.Type(xhttp.TypeForm).Post(url).SendString(param).EndBytes()
+	if len(errs) > 0 {
+		return nil, errs[0]
+	}
+	if a.DebugSwitch == gopay.DebugOn {
+		xlog.Debugf("Alipay_Response: %s%d %s%s", xlog.Red, res.StatusCode, xlog.Reset, string(bs))
+	}
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP Request Error, StatusCode = %d", res.StatusCode)
+	}
+	return bs, nil
 }
 
 // 向支付宝发送请求

--- a/alipay/client.go
+++ b/alipay/client.go
@@ -48,10 +48,21 @@ func NewClient(appId, privateKey string, isProd bool) (client *Client) {
 }
 
 // PostAliPayAPISelf 支付宝接口自行实现方法
-//	注意：需要自行解析 biz_content 后set到BodyMap，不设置则没有此参数
+//	注意：需要自行通过bm.SetBodyMap()设置，不设置则没有此参数
 //	示例：请参考 client_test.go 的 TestClient_PostAliPayAPISelf() 方法
 func (a *Client) PostAliPayAPISelf(bm gopay.BodyMap, method string, aliRsp interface{}) (err error) {
-	var bs []byte
+	var (
+		bs, bodyBs []byte
+	)
+	// check if there is biz_content
+	bz := bm.Get("biz_content")
+	if bzBody, ok := bz.(gopay.BodyMap); ok {
+		if bodyBs, err = json.Marshal(bzBody); err != nil {
+			return fmt.Errorf("json.Marshal(%v)：%w", bzBody, err)
+		}
+		bm.Set("biz_content", string(bodyBs))
+	}
+
 	if bs, err = a.doAliPaySelf(bm, method); err != nil {
 		return err
 	}
@@ -64,67 +75,27 @@ func (a *Client) PostAliPayAPISelf(bm gopay.BodyMap, method string, aliRsp inter
 // 向支付宝发送自定义请求
 func (a *Client) doAliPaySelf(bm gopay.BodyMap, method string) (bs []byte, err error) {
 	var (
-		url string
+		url, sign string
 	)
-	pubBody := make(gopay.BodyMap)
-	func() {
-		a.mu.RLock()
-		defer a.mu.RUnlock()
+	bm.Set("method", method)
 
-		pubBody.Set("app_id", a.AppId)
-		pubBody.Set("method", method)
-		pubBody.Set("format", "JSON")
-		if a.AppCertSN != util.NULL {
-			pubBody.Set("app_cert_sn", a.AppCertSN)
-		}
-		if a.AliPayRootCertSN != util.NULL {
-			pubBody.Set("alipay_root_cert_sn", a.AliPayRootCertSN)
-		}
-		if a.ReturnUrl != util.NULL {
-			pubBody.Set("return_url", a.ReturnUrl)
-		}
-		pubBody.Set("charset", "utf-8")
-		if a.Charset != util.NULL {
-			pubBody.Set("charset", a.Charset)
-		}
-		pubBody.Set("sign_type", RSA2)
-		if a.SignType != util.NULL {
-			pubBody.Set("sign_type", a.SignType)
-		}
-		pubBody.Set("timestamp", time.Now().Format(util.TimeLayout))
-		if a.LocationName != util.NULL && a.location != nil {
-			pubBody.Set("timestamp", time.Now().In(a.location).Format(util.TimeLayout))
-		}
-		pubBody.Set("version", "1.0")
-		if a.NotifyUrl != util.NULL {
-			pubBody.Set("notify_url", a.NotifyUrl)
-		}
-		if a.AppAuthToken != util.NULL {
-			pubBody.Set("app_auth_token", a.AppAuthToken)
-		}
-		if a.AuthToken != util.NULL {
-			pubBody.Set("auth_token", a.AuthToken)
-		}
-	}()
+	// check public parameter
+	a.checkPublicParam(bm)
 
-	//if bodyStr != util.NULL {
-	//	pubBody.Set("biz_content", bodyStr)
-	//}
-
-	for k, v := range bm {
-		pubBody.Set(k, v)
+	// check sign
+	if bm.GetString("sign") == "" {
+		sign, err = GetRsaSign(bm, bm.GetString("sign_type"), a.PrivateKeyType, a.PrivateKey)
+		if err != nil {
+			return nil, fmt.Errorf("GetRsaSign Error: %v", err)
+		}
+		bm.Set("sign", sign)
 	}
 
-	sign, err := GetRsaSign(pubBody, pubBody.GetString("sign_type"), a.PrivateKeyType, a.PrivateKey)
-	if err != nil {
-		return nil, fmt.Errorf("GetRsaSign Error: %v", err)
-	}
-	pubBody.Set("sign", sign)
 	if a.DebugSwitch == gopay.DebugOn {
-		req, _ := json.Marshal(pubBody)
+		req, _ := json.Marshal(bm)
 		xlog.Debugf("Alipay_Request: %s", req)
 	}
-	param := FormatURLParam(pubBody)
+	param := FormatURLParam(bm)
 
 	httpClient := xhttp.NewClient()
 	if a.IsProd {
@@ -150,53 +121,52 @@ func (a *Client) doAliPay(bm gopay.BodyMap, method string) (bs []byte, err error
 	var (
 		bodyStr, url string
 		bodyBs       []byte
+		aat, at      string
 	)
 	if bm != nil {
+		aat = bm.GetString("app_auth_token")
+		at = bm.GetString("auth_token")
 		if bodyBs, err = json.Marshal(bm); err != nil {
 			return nil, fmt.Errorf("json.Marshal：%w", err)
 		}
 		bodyStr = string(bodyBs)
 	}
-	pubBody := make(gopay.BodyMap)
-	func() {
-		a.mu.RLock()
-		defer a.mu.RUnlock()
 
-		pubBody.Set("app_id", a.AppId)
-		pubBody.Set("method", method)
-		pubBody.Set("format", "JSON")
-		if a.AppCertSN != util.NULL {
-			pubBody.Set("app_cert_sn", a.AppCertSN)
-		}
-		if a.AliPayRootCertSN != util.NULL {
-			pubBody.Set("alipay_root_cert_sn", a.AliPayRootCertSN)
-		}
-		if a.ReturnUrl != util.NULL {
-			pubBody.Set("return_url", a.ReturnUrl)
-		}
-		pubBody.Set("charset", "utf-8")
-		if a.Charset != util.NULL {
-			pubBody.Set("charset", a.Charset)
-		}
-		pubBody.Set("sign_type", RSA2)
-		if a.SignType != util.NULL {
-			pubBody.Set("sign_type", a.SignType)
-		}
-		pubBody.Set("timestamp", time.Now().Format(util.TimeLayout))
-		if a.LocationName != util.NULL && a.location != nil {
-			pubBody.Set("timestamp", time.Now().In(a.location).Format(util.TimeLayout))
-		}
-		pubBody.Set("version", "1.0")
-		if a.NotifyUrl != util.NULL {
-			pubBody.Set("notify_url", a.NotifyUrl)
-		}
-		if a.AppAuthToken != util.NULL {
-			pubBody.Set("app_auth_token", a.AppAuthToken)
-		}
-		if a.AuthToken != util.NULL {
-			pubBody.Set("auth_token", a.AuthToken)
-		}
-	}()
+	pubBody := make(gopay.BodyMap)
+	pubBody.Set("app_id", a.AppId)
+	pubBody.Set("method", method)
+	pubBody.Set("format", "JSON")
+	if a.AppCertSN != util.NULL {
+		pubBody.Set("app_cert_sn", a.AppCertSN)
+	}
+	if a.AliPayRootCertSN != util.NULL {
+		pubBody.Set("alipay_root_cert_sn", a.AliPayRootCertSN)
+	}
+	if a.ReturnUrl != util.NULL {
+		pubBody.Set("return_url", a.ReturnUrl)
+	}
+	pubBody.Set("charset", "utf-8")
+	if a.Charset != util.NULL {
+		pubBody.Set("charset", a.Charset)
+	}
+	pubBody.Set("sign_type", RSA2)
+	if a.SignType != util.NULL {
+		pubBody.Set("sign_type", a.SignType)
+	}
+	pubBody.Set("timestamp", time.Now().Format(util.TimeLayout))
+	if a.LocationName != util.NULL && a.location != nil {
+		pubBody.Set("timestamp", time.Now().In(a.location).Format(util.TimeLayout))
+	}
+	pubBody.Set("version", "1.0")
+	if a.NotifyUrl != util.NULL {
+		pubBody.Set("notify_url", a.NotifyUrl)
+	}
+	if aat == util.NULL && a.AppAuthToken != util.NULL {
+		pubBody.Set("app_auth_token", a.AppAuthToken)
+	}
+	if at == util.NULL && a.AuthToken != util.NULL {
+		pubBody.Set("auth_token", a.AuthToken)
+	}
 
 	if bodyStr != util.NULL {
 		pubBody.Set("biz_content", bodyStr)
@@ -237,6 +207,111 @@ func (a *Client) doAliPay(bm gopay.BodyMap, method string) (bs []byte, err error
 			return nil, fmt.Errorf("HTTP Request Error, StatusCode = %d", res.StatusCode)
 		}
 		return bs, nil
+	}
+}
+
+// todo: 记录
+// 向支付宝发送请求
+//func (a *Client) doAliPay(bm gopay.BodyMap, method string) (bs []byte, err error) {
+//	var (
+//		url, sign string
+//		bodyBs    []byte
+//	)
+//	bm.Set("method", method)
+//
+//	// check if there is biz_content
+//	bz := bm.Get("biz_content")
+//	if bzBody, ok := bz.(gopay.BodyMap); ok {
+//		if bodyBs, err = json.Marshal(bzBody); err != nil {
+//			return nil, fmt.Errorf("json.Marshal(%v)：%w", bzBody, err)
+//		}
+//		bm.Set("biz_content", string(bodyBs))
+//	}
+//
+//	// check public parameter
+//	a.checkPublicParam(bm)
+//
+//	// check sign
+//	if bm.GetString("sign") == "" {
+//		sign, err = GetRsaSign(bm, bm.GetString("sign_type"), a.PrivateKeyType, a.PrivateKey)
+//		if err != nil {
+//			return nil, fmt.Errorf("GetRsaSign Error: %v", err)
+//		}
+//		bm.Set("sign", sign)
+//	}
+//
+//	if a.DebugSwitch == gopay.DebugOn {
+//		req, _ := json.Marshal(bm)
+//		xlog.Debugf("Alipay_Request: %s", req)
+//	}
+//	param := FormatURLParam(bm)
+//
+//	switch method {
+//	case "alipay.trade.app.pay":
+//		return []byte(param), nil
+//	case "alipay.trade.wap.pay", "alipay.trade.page.pay", "alipay.user.certify.open.certify":
+//		if !a.IsProd {
+//			return []byte(sandboxBaseUrl + "?" + param), nil
+//		}
+//		return []byte(baseUrl + "?" + param), nil
+//	default:
+//		httpClient := xhttp.NewClient()
+//		if a.IsProd {
+//			url = baseUrlUtf8
+//		} else {
+//			url = sandboxBaseUrlUtf8
+//		}
+//		res, bs, errs := httpClient.Type(xhttp.TypeForm).Post(url).SendString(param).EndBytes()
+//		if len(errs) > 0 {
+//			return nil, errs[0]
+//		}
+//		if a.DebugSwitch == gopay.DebugOn {
+//			xlog.Debugf("Alipay_Response: %s%d %s%s", xlog.Red, res.StatusCode, xlog.Reset, string(bs))
+//		}
+//		if res.StatusCode != 200 {
+//			return nil, fmt.Errorf("HTTP Request Error, StatusCode = %d", res.StatusCode)
+//		}
+//		return bs, nil
+//	}
+//}
+
+// 公共参数检查
+func (a *Client) checkPublicParam(bm gopay.BodyMap) {
+	bm.Set("format", "JSON")
+
+	if bm.GetString("app_id") == "" && a.AppId != util.NULL {
+		bm.Set("app_id", a.AppId)
+	}
+	if bm.GetString("app_cert_sn") == "" && a.AppCertSN != util.NULL {
+		bm.Set("app_cert_sn", a.AppCertSN)
+	}
+	if bm.GetString("alipay_root_cert_sn") == "" && a.AliPayRootCertSN != util.NULL {
+		bm.Set("alipay_root_cert_sn", a.AliPayRootCertSN)
+	}
+	if bm.GetString("return_url") == "" && a.ReturnUrl != util.NULL {
+		bm.Set("return_url", a.ReturnUrl)
+	}
+	bm.Set("charset", "utf-8")
+	if bm.GetString("charset") == "" && a.Charset != util.NULL {
+		bm.Set("charset", a.Charset)
+	}
+	bm.Set("sign_type", RSA2)
+	if bm.GetString("sign_type") == "" && a.SignType != util.NULL {
+		bm.Set("sign_type", a.SignType)
+	}
+	bm.Set("timestamp", time.Now().Format(util.TimeLayout))
+	if a.LocationName != util.NULL && a.location != nil {
+		bm.Set("timestamp", time.Now().In(a.location).Format(util.TimeLayout))
+	}
+	bm.Set("version", "1.0")
+	if bm.GetString("notify_url") == "" && a.NotifyUrl != util.NULL {
+		bm.Set("notify_url", a.NotifyUrl)
+	}
+	if bm.GetString("app_auth_token") == "" && a.AppAuthToken != util.NULL {
+		bm.Set("app_auth_token", a.AppAuthToken)
+	}
+	if bm.GetString("auth_token") == "" && a.AuthToken != util.NULL {
+		bm.Set("auth_token", a.AuthToken)
 	}
 }
 

--- a/alipay/client.go
+++ b/alipay/client.go
@@ -136,10 +136,10 @@ func (a *Client) doAliPay(bm gopay.BodyMap, method string) (bs []byte, err error
 		return []byte(baseUrl + "?" + param), nil
 	default:
 		httpClient := xhttp.NewClient()
-		if !a.IsProd {
-			url = sandboxBaseUrlUtf8
-		} else {
+		if a.IsProd {
 			url = baseUrlUtf8
+		} else {
+			url = sandboxBaseUrlUtf8
 		}
 		res, bs, errs := httpClient.Type(xhttp.TypeForm).Post(url).SendString(param).EndBytes()
 		if len(errs) > 0 {

--- a/alipay/client_test.go
+++ b/alipay/client_test.go
@@ -1,7 +1,6 @@
 package alipay
 
 import (
-	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -46,20 +45,21 @@ func TestMain(m *testing.M) {
 
 func TestClient_PostAliPayAPISelf(t *testing.T) {
 	bm := make(gopay.BodyMap)
-	bm.Set("subject", "预创建创建订单")
-	bm.Set("out_trade_no", util.GetRandomString(32))
-	bm.Set("total_amount", "100")
 
-	bodyBs, err := json.Marshal(bm)
-	if err != nil {
-		xlog.Error(err)
-		return
-	}
-	// 如果需要biz_content，最后 Set
-	bm.Set("biz_content", string(bodyBs))
+	// 自定义公共参数（根据自己需求，需要独立设置的自行设置，不需要单独设置的，共享client的配置）
+	bm.Set("app_id", "appid")
+	bm.Set("app_auth_token", "app_auth_token")
+	bm.Set("auth_token", "auth_token")
+
+	// biz_content
+	bm.SetBodyMap("biz_content", func(bz gopay.BodyMap) {
+		bz.Set("subject", "预创建创建订单")
+		bz.Set("out_trade_no", util.GetRandomString(32))
+		bz.Set("total_amount", "100")
+	})
 
 	aliPsp := new(TradePrecreateResponse)
-	err = client.PostAliPayAPISelf(bm, "alipay.trade.precreate", aliPsp)
+	err := client.PostAliPayAPISelf(bm, "alipay.trade.precreate", aliPsp)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/alipay/client_test.go
+++ b/alipay/client_test.go
@@ -1,6 +1,7 @@
 package alipay
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -49,8 +50,16 @@ func TestClient_PostAliPayAPISelf(t *testing.T) {
 	bm.Set("out_trade_no", util.GetRandomString(32))
 	bm.Set("total_amount", "100")
 
+	bodyBs, err := json.Marshal(bm)
+	if err != nil {
+		xlog.Error(err)
+		return
+	}
+	// 如果需要biz_content，最后 Set
+	bm.Set("biz_content", string(bodyBs))
+
 	aliPsp := new(TradePrecreateResponse)
-	err := client.PostAliPayAPISelf(bm, "alipay.trade.precreate", aliPsp)
+	err = client.PostAliPayAPISelf(bm, "alipay.trade.precreate", aliPsp)
 	if err != nil {
 		xlog.Error(err)
 		return
@@ -272,7 +281,7 @@ func TestClient_TradeOrderSettle(t *testing.T) {
 	listParams = append(listParams, OpenApiRoyaltyDetailInfoPojo{"transfer", "2088802095984694", "userId", "userId", "2088102363632794", "0.01", "分账给2088102363632794"})
 
 	bm.Set("royalty_parameters", listParams)
-	// xlog.Debug("listParams:", bm.Get("royalty_parameters"))
+	// xlog.Debug("listParams:", bm.GetString("royalty_parameters"))
 
 	// 发起交易结算接口
 	aliRsp, err := client.TradeOrderSettle(bm)

--- a/alipay/common_api.go
+++ b/alipay/common_api.go
@@ -216,7 +216,7 @@ func systemOauthToken(appId string, t PKCSType, privateKey string, bm gopay.Body
 		sign    string
 		baseUrl = baseUrlUtf8
 	)
-	if sign, err = GetRsaSign(bm, bm.Get("sign_type"), t, privateKey); err != nil {
+	if sign, err = GetRsaSign(bm, bm.GetString("sign_type"), t, privateKey); err != nil {
 		return nil, err
 	}
 	bm.Set("sign", sign)
@@ -252,7 +252,7 @@ func MonitorHeartbeatSyn(appId string, t PKCSType, privateKey, signType, bizCont
 	bm.Set("timestamp", time.Now().Format(util.TimeLayout))
 	bm.Set("version", "1.0")
 
-	sign, err := GetRsaSign(bm, bm.Get("sign_type"), t, privateKey)
+	sign, err := GetRsaSign(bm, bm.GetString("sign_type"), t, privateKey)
 	if err != nil {
 		return nil, err
 	}

--- a/alipay/payment_api.go
+++ b/alipay/payment_api.go
@@ -132,7 +132,7 @@ func (a *Client) TradeCreate(bm gopay.BodyMap) (aliRsp *TradeCreateResponse, err
 // alipay.trade.query(统一收单线下交易查询)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/alipay.trade.query
 func (a *Client) TradeQuery(bm gopay.BodyMap) (aliRsp *TradeQueryResponse, err error) {
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("trade_no") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("trade_no") == util.NULL {
 		return nil, errors.New("out_trade_no and trade_no are not allowed to be null at the same time")
 	}
 	var bs []byte
@@ -154,7 +154,7 @@ func (a *Client) TradeQuery(bm gopay.BodyMap) (aliRsp *TradeQueryResponse, err e
 // alipay.trade.cancel(统一收单交易撤销接口)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/alipay.trade.cancel
 func (a *Client) TradeCancel(bm gopay.BodyMap) (aliRsp *TradeCancelResponse, err error) {
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("trade_no") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("trade_no") == util.NULL {
 		return nil, errors.New("out_trade_no and trade_no are not allowed to be null at the same time")
 	}
 	var bs []byte
@@ -176,7 +176,7 @@ func (a *Client) TradeCancel(bm gopay.BodyMap) (aliRsp *TradeCancelResponse, err
 // alipay.trade.close(统一收单交易关闭接口)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/alipay.trade.close
 func (a *Client) TradeClose(bm gopay.BodyMap) (aliRsp *TradeCloseResponse, err error) {
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("trade_no") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("trade_no") == util.NULL {
 		return nil, errors.New("out_trade_no and trade_no are not allowed to be null at the same time")
 	}
 	var bs []byte
@@ -198,7 +198,7 @@ func (a *Client) TradeClose(bm gopay.BodyMap) (aliRsp *TradeCloseResponse, err e
 // alipay.trade.refund(统一收单交易退款接口)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/alipay.trade.refund
 func (a *Client) TradeRefund(bm gopay.BodyMap) (aliRsp *TradeRefundResponse, err error) {
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("trade_no") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("trade_no") == util.NULL {
 		return nil, errors.New("out_trade_no and trade_no are not allowed to be null at the same time")
 	}
 	err = bm.CheckEmptyError("refund_amount")
@@ -224,7 +224,7 @@ func (a *Client) TradeRefund(bm gopay.BodyMap) (aliRsp *TradeRefundResponse, err
 // alipay.trade.page.refund(统一收单退款页面接口)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/alipay.trade.page.refund
 func (a *Client) TradePageRefund(bm gopay.BodyMap) (aliRsp *TradePageRefundResponse, err error) {
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("trade_no") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("trade_no") == util.NULL {
 		return nil, errors.New("out_trade_no and trade_no are not allowed to be null at the same time")
 	}
 	err = bm.CheckEmptyError("out_request_no", "refund_amount")
@@ -250,7 +250,7 @@ func (a *Client) TradePageRefund(bm gopay.BodyMap) (aliRsp *TradePageRefundRespo
 // alipay.trade.fastpay.refund.query(统一收单交易退款查询)
 //	文档地址：https://opendocs.alipay.com/apis/api_1/alipay.trade.fastpay.refund.query
 func (a *Client) TradeFastPayRefundQuery(bm gopay.BodyMap) (aliRsp *TradeFastpayRefundQueryResponse, err error) {
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("trade_no") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("trade_no") == util.NULL {
 		return nil, errors.New("out_trade_no and trade_no are not allowed to be null at the same time")
 	}
 	err = bm.CheckEmptyError("out_request_no")

--- a/alipay/sign.go
+++ b/alipay/sign.go
@@ -256,8 +256,8 @@ func VerifySign(aliPayPublicKey string, notifyBean interface{}) (ok bool, err er
 	)
 	if reflect.ValueOf(notifyBean).Kind() == reflect.Map {
 		if bm, ok = notifyBean.(gopay.BodyMap); ok {
-			bodySign = bm.Get("sign")
-			bodySignType = bm.Get("sign_type")
+			bodySign = bm.GetString("sign")
+			bodySignType = bm.GetString("sign_type")
 			bm.Remove("sign")
 			bm.Remove("sign_type")
 			signData = bm.EncodeAliPaySignParams()
@@ -270,8 +270,8 @@ func VerifySign(aliPayPublicKey string, notifyBean interface{}) (ok bool, err er
 		if err = json.Unmarshal(bs, &bm); err != nil {
 			return false, fmt.Errorf("json.Unmarshal(%s)：%w", string(bs), err)
 		}
-		bodySign = bm.Get("sign")
-		bodySignType = bm.Get("sign_type")
+		bodySign = bm.GetString("sign")
+		bodySignType = bm.GetString("sign_type")
 		bm.Remove("sign")
 		bm.Remove("sign_type")
 		signData = bm.EncodeAliPaySignParams()
@@ -311,8 +311,8 @@ func VerifySignWithCert(aliPayPublicKeyCert, notifyBean interface{}) (ok bool, e
 	)
 	if reflect.ValueOf(notifyBean).Kind() == reflect.Map {
 		if bm, ok = notifyBean.(gopay.BodyMap); ok {
-			bodySign = bm.Get("sign")
-			bodySignType = bm.Get("sign_type")
+			bodySign = bm.GetString("sign")
+			bodySignType = bm.GetString("sign_type")
 			bm.Remove("sign")
 			bm.Remove("sign_type")
 			signData = bm.EncodeAliPaySignParams()
@@ -325,8 +325,8 @@ func VerifySignWithCert(aliPayPublicKeyCert, notifyBean interface{}) (ok bool, e
 		if err = json.Unmarshal(bs, &bm); err != nil {
 			return false, fmt.Errorf("json.Unmarshal(%s)：%w", string(bs), err)
 		}
-		bodySign = bm.Get("sign")
-		bodySignType = bm.Get("sign_type")
+		bodySign = bm.GetString("sign")
+		bodySignType = bm.GetString("sign_type")
 		bm.Remove("sign")
 		bm.Remove("sign_type")
 		signData = bm.EncodeAliPaySignParams()

--- a/alipay/util_api.go
+++ b/alipay/util_api.go
@@ -40,7 +40,7 @@ func (a *Client) UserInfoAuth(bm gopay.BodyMap) (aliRsp *UserInfoAuthResponse, e
 // alipay.system.oauth.token(换取授权访问令牌)
 //	文档地址：https://opendocs.alipay.com/apis/api_9/alipay.system.oauth.token
 func (a *Client) SystemOauthToken(bm gopay.BodyMap) (aliRsp *SystemOauthTokenResponse, err error) {
-	if bm.Get("code") == util.NULL && bm.Get("refresh_token") == util.NULL {
+	if bm.GetString("code") == util.NULL && bm.GetString("refresh_token") == util.NULL {
 		return nil, errors.New("code and refresh_token are not allowed to be null at the same time")
 	}
 	err = bm.CheckEmptyError("grant_type")
@@ -78,7 +78,7 @@ func (a *Client) SystemOauthToken(bm gopay.BodyMap) (aliRsp *SystemOauthTokenRes
 // alipay.open.auth.token.app(换取应用授权令牌)
 //	文档地址：https://opendocs.alipay.com/apis/api_9/alipay.open.auth.token.app
 func (a *Client) OpenAuthTokenApp(bm gopay.BodyMap) (aliRsp *OpenAuthTokenAppResponse, err error) {
-	if bm.Get("code") == util.NULL && bm.Get("refresh_token") == util.NULL {
+	if bm.GetString("code") == util.NULL && bm.GetString("refresh_token") == util.NULL {
 		return nil, errors.New("code and refresh_token are not allowed to be null at the same time")
 	}
 	err = bm.CheckEmptyError("grant_type")

--- a/alipay/zhima_api.go
+++ b/alipay/zhima_api.go
@@ -11,7 +11,7 @@ import (
 // zhima.credit.score.get(查询芝麻用户的芝麻分)
 //	文档地址：https://opendocs.alipay.com/apis/api_8/zhima.credit.score.get
 func (a *Client) ZhimaCreditScoreGet(bm gopay.BodyMap) (aliRsp *ZhimaCreditScoreGetResponse, err error) {
-	if bm.Get("product_code") == util.NULL {
+	if bm.GetString("product_code") == util.NULL {
 		bm.Set("product_code", "w1010100100000000001")
 	}
 	err = bm.CheckEmptyError("transaction_id")

--- a/body_map.go
+++ b/body_map.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -40,6 +42,31 @@ func (bm BodyMap) SetBodyMap(key string, value func(bm BodyMap)) BodyMap {
 	bm[key] = _bm
 	mu.Unlock()
 	return bm
+}
+
+// 设置 FormFile
+func (bm BodyMap) SetFormFile(fieldName string, filePath string) (err error) {
+	_FileBm := make(BodyMap)
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("bm.SetFormFile(%s, %s),err:%w", fieldName, filePath, err)
+	}
+	defer file.Close()
+	stat, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("bm.SetFormFile(%s, %s),err:%w", fieldName, filePath, err)
+	}
+	fileContent := make([]byte, stat.Size())
+	_, err = file.Read(fileContent)
+	if err != nil {
+		return fmt.Errorf("bm.SetFormFile(%s, %s),err:%w", fieldName, filePath, err)
+	}
+	_FileBm[stat.Name()] = fileContent
+
+	mu.Lock()
+	bm[fieldName] = _FileBm
+	mu.Unlock()
+	return nil
 }
 
 // 获取参数

--- a/body_map.go
+++ b/body_map.go
@@ -69,8 +69,18 @@ func (bm BodyMap) SetFormFile(fieldName string, filePath string) (err error) {
 	return nil
 }
 
-// 获取参数
-func (bm BodyMap) Get(key string) string {
+// 获取原始参数
+func (bm BodyMap) Get(key string) interface{} {
+	if bm == nil {
+		return nil
+	}
+	mu.RLock()
+	defer mu.RUnlock()
+	return bm[key]
+}
+
+// 获取参数转换string
+func (bm BodyMap) GetString(key string) string {
 	if bm == nil {
 		return NULL
 	}
@@ -123,7 +133,7 @@ func (bm BodyMap) MarshalXML(e *xml.Encoder, start xml.StartElement) (err error)
 		return
 	}
 	for k := range bm {
-		if v := bm.Get(k); v != NULL {
+		if v := bm.GetString(k); v != NULL {
 			e.Encode(xmlMapMarshal{XMLName: xml.Name{Local: k}, Value: v})
 		}
 	}
@@ -157,7 +167,7 @@ func (bm BodyMap) EncodeWeChatSignParams(apiKey string) string {
 	sort.Strings(keyList)
 	mu.RUnlock()
 	for _, k := range keyList {
-		if v := bm.Get(k); v != NULL {
+		if v := bm.GetString(k); v != NULL {
 			buf.WriteString(k)
 			buf.WriteByte('=')
 			buf.WriteString(v)
@@ -183,7 +193,7 @@ func (bm BodyMap) EncodeAliPaySignParams() string {
 	sort.Strings(keyList)
 	mu.RUnlock()
 	for _, k := range keyList {
-		if v := bm.Get(k); v != NULL {
+		if v := bm.GetString(k); v != NULL {
 			buf.WriteString(k)
 			buf.WriteByte('=')
 			buf.WriteString(v)
@@ -202,7 +212,7 @@ func (bm BodyMap) EncodeGetParams() string {
 		buf strings.Builder
 	)
 	for k, _ := range bm {
-		if v := bm.Get(k); v != NULL {
+		if v := bm.GetString(k); v != NULL {
 			buf.WriteString(k)
 			buf.WriteByte('=')
 			buf.WriteString(v)
@@ -218,7 +228,7 @@ func (bm BodyMap) EncodeGetParams() string {
 func (bm BodyMap) CheckEmptyError(keys ...string) error {
 	var emptyKeys []string
 	for _, k := range keys {
-		if v := bm.Get(k); v == NULL {
+		if v := bm.GetString(k); v == NULL {
 			emptyKeys = append(emptyKeys, k)
 		}
 	}

--- a/constant.go
+++ b/constant.go
@@ -7,7 +7,7 @@ const (
 	OK       = "OK"
 	DebugOff = 0
 	DebugOn  = 1
-	Version  = "1.5.28"
+	Version  = "1.5.29"
 )
 
 type DebugSwitch int8

--- a/examples/alipay/alipay_TradeOrderSettle.go
+++ b/examples/alipay/alipay_TradeOrderSettle.go
@@ -27,7 +27,7 @@ func TradeOrderSettle() {
 	listParams = append(listParams, alipay.OpenApiRoyaltyDetailInfoPojo{"transfer", "2088802095984694", "userId", "userId", "2088102363632794", "0.01", "分账给2088102363632794"})
 
 	body.Set("royalty_parameters", listParams)
-	xlog.Debug("listParams:", body.Get("royalty_parameters"))
+	xlog.Debug("listParams:", body.GetString("royalty_parameters"))
 
 	//发起交易结算接口
 	aliRsp, err := client.TradeOrderSettle(body)

--- a/examples/wechat/wx_ServiceApi.go
+++ b/examples/wechat/wx_ServiceApi.go
@@ -244,7 +244,7 @@ func ParseWeChatRefundNotify(req *http.Request) string {
 	xlog.Debug("bodyMap:", bodyMap)
 
 	// 解密退款异步通知的加密数据
-	refundNotify2, err := wechat.DecryptRefundNotifyReqInfo(bodyMap.Get("req_info"), "GFDS8j98rewnmgl45wHTt980jg543abc")
+	refundNotify2, err := wechat.DecryptRefundNotifyReqInfo(bodyMap.GetString("req_info"), "GFDS8j98rewnmgl45wHTt980jg543abc")
 	if err != nil {
 		xlog.Debug("err:", err)
 	}

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -1,0 +1,18 @@
+package util
+
+import "encoding/json"
+
+func ConvertToString(v interface{}) (str string) {
+	if v == nil {
+		return NULL
+	}
+	var (
+		bs  []byte
+		err error
+	)
+	if bs, err = json.Marshal(v); err != nil {
+		return NULL
+	}
+	str = string(bs)
+	return
+}

--- a/pkg/xhttp/client.go
+++ b/pkg/xhttp/client.go
@@ -356,7 +356,7 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 						continue
 					}
 					// text 参数
-					if val := c.multipartBodyMap.Get(k); val != gopay.NULL {
+					if val := c.multipartBodyMap.GetString(k); val != gopay.NULL {
 						w.WriteField(k, val)
 					}
 				}

--- a/pkg/xhttp/client.go
+++ b/pkg/xhttp/client.go
@@ -1,6 +1,7 @@
 package xhttp
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
@@ -8,11 +9,13 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/iGoogle-ink/gopay"
 	"github.com/iGoogle-ink/gopay/pkg/util"
 )
 
@@ -113,7 +116,8 @@ type Client struct {
 	// unmarshalType json or xml
 	unmarshalType string
 
-	types map[string]string
+	// types            map[string]string
+	multipartBodyMap gopay.BodyMap
 
 	jsonByte []byte
 
@@ -223,6 +227,25 @@ func (c *Client) SendBodyMap(v interface{}) (client *Client) {
 	return c
 }
 
+func (c *Client) SendMultipartBodyMap(bm gopay.BodyMap) (client *Client) {
+	bs, err := json.Marshal(bm)
+	if err != nil {
+		c.Errors = append(c.Errors, err)
+		return c
+	}
+	c.mu.Lock()
+	switch c.requestType {
+	case TypeJSON:
+		c.jsonByte = bs
+	case TypeXML, TypeUrlencoded, TypeForm, TypeFormData:
+		c.FormString = string(bs)
+	case TypeMultipartFormData:
+		c.multipartBodyMap = bm
+	}
+	c.mu.Unlock()
+	return c
+}
+
 // encodeStr: url.Values.Encode() or jsonBody
 func (c *Client) SendString(encodeStr string) (client *Client) {
 	c.mu.Lock()
@@ -274,12 +297,22 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 	if len(c.Errors) > 0 {
 		return nil, nil, c.Errors
 	}
-	var reader = strings.NewReader(util.NULL)
+	var (
+		body io.Reader = strings.NewReader(util.NULL)
+		w    *multipart.Writer
+	)
+	// multipart-form-data
+	if c.requestType == TypeMultipartFormData {
+		body = &bytes.Buffer{}
+		w = multipart.NewWriter(body.(io.Writer))
+	}
 
 	req, err := func() (*http.Request, error) {
 		c.mu.RLock()
 		defer c.mu.RUnlock()
-
+		if c.requestType == TypeMultipartFormData {
+			defer w.Close()
+		}
 		switch c.method {
 		case GET:
 			switch c.requestType {
@@ -287,6 +320,8 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 				c.ContentType = types[TypeJSON]
 			case TypeForm, TypeFormData, TypeUrlencoded:
 				c.ContentType = types[TypeForm]
+			case TypeMultipartFormData:
+				c.ContentType = w.FormDataContentType()
 			case TypeXML:
 				c.ContentType = types[TypeXML]
 				c.unmarshalType = string(TypeXML)
@@ -297,14 +332,37 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 			switch c.requestType {
 			case TypeJSON:
 				if c.jsonByte != nil {
-					reader = strings.NewReader(string(c.jsonByte))
+					body = strings.NewReader(string(c.jsonByte))
 				}
 				c.ContentType = types[TypeJSON]
 			case TypeForm, TypeFormData, TypeUrlencoded:
-				reader = strings.NewReader(c.FormString)
+				body = strings.NewReader(c.FormString)
 				c.ContentType = types[TypeForm]
+			case TypeMultipartFormData:
+				for k, v := range c.multipartBodyMap {
+					// file 参数
+					if bm, ok := v.(gopay.BodyMap); ok {
+						for fileName, fileContent := range bm {
+							// 遍历，如果fileContent是 []byte数组，说明是文件
+							fb, ok2 := fileContent.([]byte)
+							if ok2 {
+								file, err := w.CreateFormFile(k, fileName)
+								if err != nil {
+									return nil, err
+								}
+								file.Write(fb)
+							}
+						}
+						continue
+					}
+					// text 参数
+					if val := c.multipartBodyMap.Get(k); val != gopay.NULL {
+						w.WriteField(k, val)
+					}
+				}
+				c.ContentType = w.FormDataContentType()
 			case TypeXML:
-				reader = strings.NewReader(c.FormString)
+				body = strings.NewReader(c.FormString)
 				c.ContentType = types[TypeXML]
 				c.unmarshalType = string(TypeXML)
 			default:
@@ -314,7 +372,7 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 			return nil, errors.New("Only support Get and Post ")
 		}
 
-		req, err := http.NewRequest(c.method, c.url, reader)
+		req, err := http.NewRequest(c.method, c.url, body)
 		if err != nil {
 			return nil, err
 		}
@@ -327,6 +385,7 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 		c.Errors = append(c.Errors, err)
 		return nil, nil, c.Errors
 	}
+
 	if c.Timeout != time.Duration(0) {
 		c.HttpClient.Timeout = c.Timeout
 	}
@@ -339,7 +398,7 @@ func (c *Client) EndBytes() (res *http.Response, bs []byte, errs []error) {
 		return nil, nil, c.Errors
 	}
 	defer res.Body.Close()
-	bs, err = ioutil.ReadAll(io.LimitReader(res.Body, int64(3<<20))) // default 3MB change the size you want
+	bs, err = ioutil.ReadAll(io.LimitReader(res.Body, int64(5<<20))) // default 5MB change the size you want
 	if err != nil {
 		c.Errors = append(c.Errors, err)
 		return nil, nil, c.Errors

--- a/pkg/xhttp/model.go
+++ b/pkg/xhttp/model.go
@@ -3,19 +3,21 @@ package xhttp
 type RequestType string
 
 const (
-	POST                       = "POST"
-	GET                        = "GET"
-	TypeJSON       RequestType = "json"
-	TypeXML        RequestType = "xml"
-	TypeUrlencoded RequestType = "urlencoded"
-	TypeForm       RequestType = "form"
-	TypeFormData   RequestType = "form-data"
+	POST                              = "POST"
+	GET                               = "GET"
+	TypeJSON              RequestType = "json"
+	TypeXML               RequestType = "xml"
+	TypeUrlencoded        RequestType = "urlencoded"
+	TypeForm              RequestType = "form"
+	TypeFormData          RequestType = "form-data"
+	TypeMultipartFormData RequestType = "multipart-form-data"
 )
 
 var types = map[RequestType]string{
-	TypeJSON:       "application/json",
-	TypeXML:        "application/xml",
-	TypeForm:       "application/x-www-form-urlencoded",
-	TypeFormData:   "application/x-www-form-urlencoded",
-	TypeUrlencoded: "application/x-www-form-urlencoded",
+	TypeJSON:              "application/json",
+	TypeXML:               "application/xml",
+	TypeUrlencoded:        "application/x-www-form-urlencoded",
+	TypeForm:              "application/x-www-form-urlencoded",
+	TypeFormData:          "application/x-www-form-urlencoded",
+	TypeMultipartFormData: "multipart/form-data",
 }

--- a/qq/client.go
+++ b/qq/client.go
@@ -264,16 +264,13 @@ func (q *Client) doQQ(bm gopay.BodyMap, url string, tlsConfig *tls.Config) (bs [
 
 // Get请求、正式
 func (q *Client) doQQGet(bm gopay.BodyMap, url, signType string) (bs []byte, err error) {
-	func() {
-		q.mu.RLock()
-		defer q.mu.RUnlock()
-		if bm.GetString("mch_id") == util.NULL {
-			bm.Set("mch_id", q.MchId)
-		}
-		bm.Remove("sign")
-		sign := getReleaseSign(q.ApiKey, signType, bm)
-		bm.Set("sign", sign)
-	}()
+	if bm.GetString("mch_id") == util.NULL {
+		bm.Set("mch_id", q.MchId)
+	}
+	bm.Remove("sign")
+	sign := getReleaseSign(q.ApiKey, signType, bm)
+	bm.Set("sign", sign)
+
 	if q.DebugSwitch == gopay.DebugOn {
 		req, _ := json.Marshal(bm)
 		xlog.Debugf("QQ_Request: %s", req)
@@ -298,18 +295,13 @@ func (q *Client) doQQGet(bm gopay.BodyMap, url, signType string) (bs []byte, err
 
 func (q *Client) doQQRed(bm gopay.BodyMap, url string, tlsConfig *tls.Config) (bs []byte, err error) {
 
-	func() {
-		q.mu.RLock()
-		defer q.mu.RUnlock()
-
-		if bm.GetString("mch_id") == util.NULL {
-			bm.Set("mch_id", q.MchId)
-		}
-		if bm.GetString("sign") == util.NULL {
-			sign := getReleaseSign(q.ApiKey, SignType_MD5, bm)
-			bm.Set("sign", sign)
-		}
-	}()
+	if bm.GetString("mch_id") == util.NULL {
+		bm.Set("mch_id", q.MchId)
+	}
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(q.ApiKey, SignType_MD5, bm)
+		bm.Set("sign", sign)
+	}
 
 	httpClient := xhttp.NewClient()
 	if tlsConfig != nil {

--- a/qq/client.go
+++ b/qq/client.go
@@ -105,7 +105,7 @@ func (q *Client) OrderQuery(bm gopay.BodyMap) (qqRsp *OrderQueryResponse, err er
 	if err != nil {
 		return nil, err
 	}
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("transaction_id") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("transaction_id") == util.NULL {
 		return nil, errors.New("out_trade_no and transaction_id are not allowed to be null at the same time")
 	}
 	bs, err := q.doQQ(bm, orderQuery, nil)
@@ -148,7 +148,7 @@ func (q *Client) Refund(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FileP
 	if err != nil {
 		return nil, err
 	}
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("transaction_id") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("transaction_id") == util.NULL {
 		return nil, errors.New("out_trade_no and transaction_id are not allowed to be null at the same time")
 	}
 	tlsConfig, err := q.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
@@ -173,7 +173,7 @@ func (q *Client) RefundQuery(bm gopay.BodyMap) (qqRsp *RefundQueryResponse, err 
 	if err != nil {
 		return nil, err
 	}
-	if bm.Get("refund_id") == util.NULL && bm.Get("out_refund_no") == util.NULL && bm.Get("transaction_id") == util.NULL && bm.Get("out_trade_no") == util.NULL {
+	if bm.GetString("refund_id") == util.NULL && bm.GetString("out_refund_no") == util.NULL && bm.GetString("transaction_id") == util.NULL && bm.GetString("out_trade_no") == util.NULL {
 		return nil, errors.New("refund_id, out_refund_no, out_trade_no, transaction_id are not allowed to be null at the same time")
 	}
 	bs, err := q.doQQ(bm, refundQuery, nil)
@@ -194,7 +194,7 @@ func (q *Client) StatementDown(bm gopay.BodyMap) (qqRsp string, err error) {
 	if err != nil {
 		return util.NULL, err
 	}
-	billType := bm.Get("bill_type")
+	billType := bm.GetString("bill_type")
 	if billType != "ALL" && billType != "SUCCESS" && billType != "REFUND" && billType != "RECHAR" {
 		return util.NULL, errors.New("bill_type error, please reference: https://qpay.qq.com/buss/wiki/38/1209")
 	}
@@ -212,7 +212,7 @@ func (q *Client) AccRoll(bm gopay.BodyMap) (qqRsp string, err error) {
 	if err != nil {
 		return util.NULL, err
 	}
-	accType := bm.Get("acc_type")
+	accType := bm.GetString("acc_type")
 	if accType != "CASH" && accType != "MARKETING" {
 		return util.NULL, errors.New("acc_type error, please reference: https://qpay.qq.com/buss/wiki/38/3089")
 	}
@@ -226,15 +226,15 @@ func (q *Client) AccRoll(bm gopay.BodyMap) (qqRsp string, err error) {
 // 向QQ发送请求
 func (q *Client) doQQ(bm gopay.BodyMap, url string, tlsConfig *tls.Config) (bs []byte, err error) {
 
-	if bm.Get("mch_id") == util.NULL {
+	if bm.GetString("mch_id") == util.NULL {
 		bm.Set("mch_id", q.MchId)
 	}
-	if bm.Get("fee_type") == util.NULL {
+	if bm.GetString("fee_type") == util.NULL {
 		bm.Set("fee_type", "CNY")
 	}
 
-	if bm.Get("sign") == util.NULL {
-		sign := getReleaseSign(q.ApiKey, bm.Get("sign_type"), bm)
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(q.ApiKey, bm.GetString("sign_type"), bm)
 		bm.Set("sign", sign)
 	}
 
@@ -267,7 +267,7 @@ func (q *Client) doQQGet(bm gopay.BodyMap, url, signType string) (bs []byte, err
 	func() {
 		q.mu.RLock()
 		defer q.mu.RUnlock()
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", q.MchId)
 		}
 		bm.Remove("sign")
@@ -302,10 +302,10 @@ func (q *Client) doQQRed(bm gopay.BodyMap, url string, tlsConfig *tls.Config) (b
 		q.mu.RLock()
 		defer q.mu.RUnlock()
 
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", q.MchId)
 		}
-		if bm.Get("sign") == util.NULL {
+		if bm.GetString("sign") == util.NULL {
 			sign := getReleaseSign(q.ApiKey, SignType_MD5, bm)
 			bm.Set("sign", sign)
 		}

--- a/qq/payment_api.go
+++ b/qq/payment_api.go
@@ -62,7 +62,7 @@ func VerifySign(apiKey, signType string, bean interface{}) (ok bool, err error) 
 	kind := reflect.ValueOf(bean).Kind()
 	if kind == reflect.Map {
 		bm := bean.(gopay.BodyMap)
-		bodySign := bm.Get("sign")
+		bodySign := bm.GetString("sign")
 		bm.Remove("sign")
 		return getReleaseSign(apiKey, signType, bm) == bodySign, nil
 	}
@@ -75,7 +75,7 @@ func VerifySign(apiKey, signType string, bean interface{}) (ok bool, err error) 
 	if err = json.Unmarshal(bs, &bm); err != nil {
 		return false, fmt.Errorf("json.Marshal(%s)：%w", string(bs), err)
 	}
-	bodySign := bm.Get("sign")
+	bodySign := bm.GetString("sign")
 	bm.Remove("sign")
 	return getReleaseSign(apiKey, signType, bm) == bodySign, nil
 }

--- a/release_note.txt
+++ b/release_note.txt
@@ -1,3 +1,9 @@
+版本号：Release 1.5.29
+发布时间：2021/02/23 21:32
+修改记录：
+   (1) 支付宝：重构 client.PostAliPayAPISelf()，具体参考 client_test.go 内的 TestClient_PostAliPayAPISelf() 方法
+   (2) BodyMap：新增 bm.SetFormFile() 的部分方法，修改 bm.Get() 方法，新增bm.GetString() 方法
+
 版本号：Release 1.5.28
 发布时间：2021/02/19 18:48
 修改记录：

--- a/release_note.txt
+++ b/release_note.txt
@@ -3,6 +3,7 @@
 修改记录：
    (1) 支付宝：重构 client.PostAliPayAPISelf()，具体参考 client_test.go 内的 TestClient_PostAliPayAPISelf() 方法
    (2) BodyMap：新增 bm.SetFormFile() 的部分方法，修改 bm.Get() 方法，新增bm.GetString() 方法
+   (3) xHttp：更新 httpClient， httpClient.Type() 支持 TypeMultipartFormData 类型
 
 版本号：Release 1.5.28
 发布时间：2021/02/19 18:48

--- a/wechat/base_api.go
+++ b/wechat/base_api.go
@@ -65,7 +65,7 @@ func (w *Client) QueryOrder(bm gopay.BodyMap) (wxRsp *QueryOrderResponse, resBm 
 	if err != nil {
 		return nil, nil, err
 	}
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("transaction_id") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("transaction_id") == util.NULL {
 		return nil, nil, errors.New("out_trade_no and transaction_id are not allowed to be null at the same time")
 	}
 	var bs []byte
@@ -122,7 +122,7 @@ func (w *Client) Refund(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FileP
 	if err != nil {
 		return nil, nil, err
 	}
-	if bm.Get("out_trade_no") == util.NULL && bm.Get("transaction_id") == util.NULL {
+	if bm.GetString("out_trade_no") == util.NULL && bm.GetString("transaction_id") == util.NULL {
 		return nil, nil, errors.New("out_trade_no and transaction_id are not allowed to be null at the same time")
 	}
 	var (
@@ -158,7 +158,7 @@ func (w *Client) QueryRefund(bm gopay.BodyMap) (wxRsp *QueryRefundResponse, resB
 	if err != nil {
 		return nil, nil, err
 	}
-	if bm.Get("refund_id") == util.NULL && bm.Get("out_refund_no") == util.NULL && bm.Get("transaction_id") == util.NULL && bm.Get("out_trade_no") == util.NULL {
+	if bm.GetString("refund_id") == util.NULL && bm.GetString("out_refund_no") == util.NULL && bm.GetString("transaction_id") == util.NULL && bm.GetString("out_trade_no") == util.NULL {
 		return nil, nil, errors.New("refund_id, out_refund_no, out_trade_no, transaction_id are not allowed to be null at the same time")
 	}
 	var bs []byte

--- a/wechat/client.go
+++ b/wechat/client.go
@@ -75,7 +75,7 @@ func (w *Client) DownloadBill(bm gopay.BodyMap) (wxRsp string, err error) {
 	if err != nil {
 		return util.NULL, err
 	}
-	billType := bm.Get("bill_type")
+	billType := bm.GetString("bill_type")
 	if billType != "ALL" && billType != "SUCCESS" && billType != "REFUND" && billType != "RECHARGE_REFUND" {
 		return util.NULL, errors.New("bill_type error, please reference: https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_6")
 	}
@@ -103,7 +103,7 @@ func (w *Client) DownloadFundFlow(bm gopay.BodyMap, certFilePath, keyFilePath, p
 	if err != nil {
 		return util.NULL, err
 	}
-	accountType := bm.Get("account_type")
+	accountType := bm.GetString("account_type")
 	if accountType != "Basic" && accountType != "Operation" && accountType != "Fees" {
 		return util.NULL, errors.New("account_type error, please reference: https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_18&index=7")
 	}
@@ -180,7 +180,7 @@ func (w *Client) doSanBoxPost(bm gopay.BodyMap, path string) (bs []byte, err err
 	bm.Set("appid", w.AppId)
 	bm.Set("mch_id", w.MchId)
 
-	if bm.Get("sign") == util.NULL {
+	if bm.GetString("sign") == util.NULL {
 		bm.Set("sign_type", SignType_MD5)
 		sign, err := getSignBoxSign(w.MchId, w.ApiKey, bm)
 		if err != nil {
@@ -218,14 +218,14 @@ func (w *Client) doProdPost(bm gopay.BodyMap, path string, tlsConfig *tls.Config
 	func() {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", w.AppId)
 		}
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", w.MchId)
 		}
-		if bm.Get("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, bm.Get("sign_type"), bm)
+		if bm.GetString("sign") == util.NULL {
+			sign := getReleaseSign(w.ApiKey, bm.GetString("sign_type"), bm)
 			bm.Set("sign", sign)
 		}
 	}()
@@ -291,10 +291,10 @@ func (w *Client) doProdGet(bm gopay.BodyMap, path, signType string) (bs []byte, 
 	func() {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", w.AppId)
 		}
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", w.MchId)
 		}
 		bm.Remove("sign")

--- a/wechat/merchant.go
+++ b/wechat/merchant.go
@@ -228,7 +228,7 @@ func (w *Client) GetRSAPublicKey(bm gopay.BodyMap, certFilePath, keyFilePath, pk
 	if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
 		return nil, err
 	}
-	bm.Set("sign", getReleaseSign(w.ApiKey, bm.Get("sign_type"), bm))
+	bm.Set("sign", getReleaseSign(w.ApiKey, bm.GetString("sign_type"), bm))
 
 	httpClient := xhttp.NewClient().SetTLSConfig(tlsConfig).Type(xhttp.TypeXML)
 	req := GenerateXml(bm)
@@ -314,8 +314,8 @@ func (w *Client) ProfitSharingQuery(bm gopay.BodyMap) (wxRsp *ProfitSharingQuery
 		w.mu.RLock()
 		defer w.mu.RUnlock()
 		bm.Set("mch_id", w.MchId)
-		if bm.Get("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, bm.Get("sign_type"), bm)
+		if bm.GetString("sign") == util.NULL {
+			sign := getReleaseSign(w.ApiKey, bm.GetString("sign_type"), bm)
 			bm.Set("sign", sign)
 		}
 	}()
@@ -421,7 +421,7 @@ func (w *Client) ProfitSharingReturn(bm gopay.BodyMap, certFilePath, keyFilePath
 		return nil, err
 	}
 
-	if (bm.Get("order_id") == util.NULL) && (bm.Get("out_order_no") == util.NULL) {
+	if (bm.GetString("order_id") == util.NULL) && (bm.GetString("out_order_no") == util.NULL) {
 		return nil, errors.New("param order_id and out_order_no can not be null at the same time")
 	}
 	// 设置签名类型，官方文档此接口只支持 HMAC_SHA256
@@ -452,7 +452,7 @@ func (w *Client) ProfitSharingReturnQuery(bm gopay.BodyMap) (wxRsp *ProfitSharin
 		return nil, err
 	}
 
-	if (bm.Get("order_id") == util.NULL) && (bm.Get("out_order_no") == util.NULL) {
+	if (bm.GetString("order_id") == util.NULL) && (bm.GetString("out_order_no") == util.NULL) {
 		return nil, errors.New("param order_id and out_order_no can not be null at the same time")
 	}
 	// 设置签名类型，官方文档此接口只支持 HMAC_SHA256

--- a/wechat/merchant.go
+++ b/wechat/merchant.go
@@ -310,15 +310,11 @@ func (w *Client) ProfitSharingQuery(bm gopay.BodyMap) (wxRsp *ProfitSharingQuery
 	}
 	// 设置签名类型，官方文档此接口只支持 HMAC_SHA256
 	bm.Set("sign_type", SignType_HMAC_SHA256)
-	func() {
-		w.mu.RLock()
-		defer w.mu.RUnlock()
-		bm.Set("mch_id", w.MchId)
-		if bm.GetString("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, bm.GetString("sign_type"), bm)
-			bm.Set("sign", sign)
-		}
-	}()
+	bm.Set("mch_id", w.MchId)
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(w.ApiKey, bm.GetString("sign_type"), bm)
+		bm.Set("sign", sign)
+	}
 	bs, err := w.doProdPostPure(bm, profitSharingQuery, nil)
 	if err != nil {
 		return nil, err

--- a/wechat/payment_api.go
+++ b/wechat/payment_api.go
@@ -43,7 +43,7 @@ func GetParamSign(appId, mchId, apiKey string, bm gopay.BodyMap) (sign string) {
 		signType string
 		h        hash.Hash
 	)
-	signType = bm.Get("sign_type")
+	signType = bm.GetString("sign_type")
 	if signType == util.NULL {
 		bm.Set("sign_type", SignType_MD5)
 	}
@@ -192,7 +192,7 @@ func VerifySign(apiKey, signType string, bean interface{}) (ok bool, err error) 
 	kind := reflect.ValueOf(bean).Kind()
 	if kind == reflect.Map {
 		bm := bean.(gopay.BodyMap)
-		bodySign := bm.Get("sign")
+		bodySign := bm.GetString("sign")
 		bm.Remove("sign")
 		return getReleaseSign(apiKey, signType, bm) == bodySign, nil
 	}
@@ -205,7 +205,7 @@ func VerifySign(apiKey, signType string, bean interface{}) (ok bool, err error) 
 	if err = json.Unmarshal(bs, &bm); err != nil {
 		return false, fmt.Errorf("json.Marshal(%s)：%w", string(bs), err)
 	}
-	bodySign := bm.Get("sign")
+	bodySign := bm.GetString("sign")
 	bm.Remove("sign")
 	return getReleaseSign(apiKey, signType, bm) == bodySign, nil
 }

--- a/wechat/payment_api.go
+++ b/wechat/payment_api.go
@@ -270,7 +270,7 @@ func GetMiniPaySign(appId, nonceStr, packages, signType, timeStamp, apiKey strin
 //	signType：签名类型
 //	timeStamp：时间
 //	ApiKey：API秘钥值
-//	微信内H5支付官方文档：https://pay.weixin.qq.com/wiki/doc/api/external/jsapi.php?chapter=7_7&index=6
+//	微信内H5支付官方文档：https://pay.weixin.qq.com/wiki/doc/api/wxpay/ch/pay/OfficialPayMent/chapter5_5.shtml
 func GetH5PaySign(appId, nonceStr, packages, signType, timeStamp, apiKey string) (paySign string) {
 	var (
 		buffer strings.Builder

--- a/wechat/red.go
+++ b/wechat/red.go
@@ -24,21 +24,16 @@ func (w *Client) SendCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12
 	if err != nil {
 		return nil, err
 	}
-
-	func() {
-		w.mu.RLock()
-		defer w.mu.RUnlock()
-		if bm.GetString("wxappid") == util.NULL {
-			bm.Set("wxappid", w.AppId)
-		}
-		if bm.GetString("mch_id") == util.NULL {
-			bm.Set("mch_id", w.MchId)
-		}
-		if bm.GetString("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
-			bm.Set("sign", sign)
-		}
-	}()
+	if bm.GetString("wxappid") == util.NULL {
+		bm.Set("wxappid", w.AppId)
+	}
+	if bm.GetString("mch_id") == util.NULL {
+		bm.Set("mch_id", w.MchId)
+	}
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
+		bm.Set("sign", sign)
+	}
 
 	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
 	if err != nil {
@@ -68,20 +63,16 @@ func (w *Client) SendGroupCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, p
 		return nil, err
 	}
 
-	func() {
-		w.mu.RLock()
-		defer w.mu.RUnlock()
-		if bm.GetString("wxappid") == util.NULL {
-			bm.Set("wxappid", w.AppId)
-		}
-		if bm.GetString("mch_id") == util.NULL {
-			bm.Set("mch_id", w.MchId)
-		}
-		if bm.GetString("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
-			bm.Set("sign", sign)
-		}
-	}()
+	if bm.GetString("wxappid") == util.NULL {
+		bm.Set("wxappid", w.AppId)
+	}
+	if bm.GetString("mch_id") == util.NULL {
+		bm.Set("mch_id", w.MchId)
+	}
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
+		bm.Set("sign", sign)
+	}
 
 	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
 	if err != nil {
@@ -111,20 +102,16 @@ func (w *Client) SendAppletRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs
 		return nil, err
 	}
 
-	func() {
-		w.mu.RLock()
-		defer w.mu.RUnlock()
-		if bm.GetString("wxappid") == util.NULL {
-			bm.Set("wxappid", w.AppId)
-		}
-		if bm.GetString("mch_id") == util.NULL {
-			bm.Set("mch_id", w.MchId)
-		}
-		if bm.GetString("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
-			bm.Set("sign", sign)
-		}
-	}()
+	if bm.GetString("wxappid") == util.NULL {
+		bm.Set("wxappid", w.AppId)
+	}
+	if bm.GetString("mch_id") == util.NULL {
+		bm.Set("mch_id", w.MchId)
+	}
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
+		bm.Set("sign", sign)
+	}
 
 	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
 	if err != nil {
@@ -154,20 +141,16 @@ func (w *Client) QueryRedRecord(bm gopay.BodyMap, certFilePath, keyFilePath, pkc
 		return nil, err
 	}
 
-	func() {
-		w.mu.RLock()
-		defer w.mu.RUnlock()
-		if bm.GetString("appid") == util.NULL {
-			bm.Set("appid", w.AppId)
-		}
-		if bm.GetString("mch_id") == util.NULL {
-			bm.Set("mch_id", w.MchId)
-		}
-		if bm.GetString("sign") == util.NULL {
-			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
-			bm.Set("sign", sign)
-		}
-	}()
+	if bm.GetString("appid") == util.NULL {
+		bm.Set("appid", w.AppId)
+	}
+	if bm.GetString("mch_id") == util.NULL {
+		bm.Set("mch_id", w.MchId)
+	}
+	if bm.GetString("sign") == util.NULL {
+		sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
+		bm.Set("sign", sign)
+	}
 
 	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
 	if err != nil {

--- a/wechat/red.go
+++ b/wechat/red.go
@@ -28,13 +28,13 @@ func (w *Client) SendCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12
 	func() {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if bm.Get("wxappid") == util.NULL {
+		if bm.GetString("wxappid") == util.NULL {
 			bm.Set("wxappid", w.AppId)
 		}
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", w.MchId)
 		}
-		if bm.Get("sign") == util.NULL {
+		if bm.GetString("sign") == util.NULL {
 			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
 			bm.Set("sign", sign)
 		}
@@ -71,13 +71,13 @@ func (w *Client) SendGroupCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, p
 	func() {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if bm.Get("wxappid") == util.NULL {
+		if bm.GetString("wxappid") == util.NULL {
 			bm.Set("wxappid", w.AppId)
 		}
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", w.MchId)
 		}
-		if bm.Get("sign") == util.NULL {
+		if bm.GetString("sign") == util.NULL {
 			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
 			bm.Set("sign", sign)
 		}
@@ -114,13 +114,13 @@ func (w *Client) SendAppletRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs
 	func() {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if bm.Get("wxappid") == util.NULL {
+		if bm.GetString("wxappid") == util.NULL {
 			bm.Set("wxappid", w.AppId)
 		}
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", w.MchId)
 		}
-		if bm.Get("sign") == util.NULL {
+		if bm.GetString("sign") == util.NULL {
 			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
 			bm.Set("sign", sign)
 		}
@@ -157,13 +157,13 @@ func (w *Client) QueryRedRecord(bm gopay.BodyMap, certFilePath, keyFilePath, pkc
 	func() {
 		w.mu.RLock()
 		defer w.mu.RUnlock()
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", w.AppId)
 		}
-		if bm.Get("mch_id") == util.NULL {
+		if bm.GetString("mch_id") == util.NULL {
 			bm.Set("mch_id", w.MchId)
 		}
-		if bm.Get("sign") == util.NULL {
+		if bm.GetString("sign") == util.NULL {
 			sign := getReleaseSign(w.ApiKey, SignType_MD5, bm)
 			bm.Set("sign", sign)
 		}

--- a/wechat/v3/pay_public_api.go
+++ b/wechat/v3/pay_public_api.go
@@ -19,10 +19,10 @@ func (c *ClientV3) V3TransactionApp(bm gopay.BodyMap) (wxRsp *PrepayRsp, err err
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", c.Appid)
 		}
-		if bm.Get("mchid") == util.NULL {
+		if bm.GetString("mchid") == util.NULL {
 			bm.Set("mchid", c.Mchid)
 		}
 	}
@@ -54,10 +54,10 @@ func (c *ClientV3) V3TransactionJsapi(bm gopay.BodyMap) (wxRsp *PrepayRsp, err e
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", c.Appid)
 		}
-		if bm.Get("mchid") == util.NULL {
+		if bm.GetString("mchid") == util.NULL {
 			bm.Set("mchid", c.Mchid)
 		}
 	}
@@ -89,10 +89,10 @@ func (c *ClientV3) V3TransactionNative(bm gopay.BodyMap) (wxRsp *NativeRsp, err 
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", c.Appid)
 		}
-		if bm.Get("mchid") == util.NULL {
+		if bm.GetString("mchid") == util.NULL {
 			bm.Set("mchid", c.Mchid)
 		}
 	}
@@ -124,10 +124,10 @@ func (c *ClientV3) V3TransactionH5(bm gopay.BodyMap) (wxRsp *H5Rsp, err error) {
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("appid") == util.NULL {
+		if bm.GetString("appid") == util.NULL {
 			bm.Set("appid", c.Appid)
 		}
-		if bm.Get("mchid") == util.NULL {
+		if bm.GetString("mchid") == util.NULL {
 			bm.Set("mchid", c.Mchid)
 		}
 	}
@@ -231,7 +231,7 @@ func (c *ClientV3) V3BillTradeBill(bm gopay.BodyMap) (wxRsp *BillRsp, err error)
 		uri      string
 	)
 	if bm != nil {
-		if bm.Get("bill_date") == util.NULL {
+		if bm.GetString("bill_date") == util.NULL {
 			now := time.Now()
 			yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.Local).Format(util.DateLayout)
 			bm.Set("bill_date", yesterday)
@@ -271,7 +271,7 @@ func (c *ClientV3) V3BillFundFlowBill(bm gopay.BodyMap) (wxRsp *BillRsp, err err
 		uri      string
 	)
 	if bm != nil {
-		if bm.Get("bill_date") == util.NULL {
+		if bm.GetString("bill_date") == util.NULL {
 			now := time.Now()
 			yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.Local).Format(util.DateLayout)
 			bm.Set("bill_date", yesterday)
@@ -311,15 +311,15 @@ func (c *ClientV3) V3BillLevel2FundFlowBill(bm gopay.BodyMap) (wxRsp *Level2Fund
 		uri      string
 	)
 	if bm != nil {
-		if bm.Get("bill_date") == util.NULL {
+		if bm.GetString("bill_date") == util.NULL {
 			now := time.Now()
 			yesterday := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.Local).Format(util.DateLayout)
 			bm.Set("bill_date", yesterday)
 		}
-		if bm.Get("account_type") == util.NULL {
+		if bm.GetString("account_type") == util.NULL {
 			bm.Set("account_type", "ALL")
 		}
-		if bm.Get("algorithm") == util.NULL {
+		if bm.GetString("algorithm") == util.NULL {
 			bm.Set("algorithm", "AEAD_AES_256_GCM")
 		}
 
@@ -383,10 +383,10 @@ func (c *ClientV3) V3CombineTransactionApp(bm gopay.BodyMap) (wxRsp *PrepayRsp, 
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("combine_appid") == util.NULL {
+		if bm.GetString("combine_appid") == util.NULL {
 			bm.Set("combine_appid", c.Appid)
 		}
-		if bm.Get("combine_mchid") == util.NULL {
+		if bm.GetString("combine_mchid") == util.NULL {
 			bm.Set("combine_mchid", c.Mchid)
 		}
 	}
@@ -418,10 +418,10 @@ func (c *ClientV3) V3CombineTransactionH5(bm gopay.BodyMap) (wxRsp *H5Rsp, err e
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("combine_appid") == util.NULL {
+		if bm.GetString("combine_appid") == util.NULL {
 			bm.Set("combine_appid", c.Appid)
 		}
-		if bm.Get("combine_mchid") == util.NULL {
+		if bm.GetString("combine_mchid") == util.NULL {
 			bm.Set("combine_mchid", c.Mchid)
 		}
 	}
@@ -454,10 +454,10 @@ func (c *ClientV3) V3CombineTransactionJsapi(bm gopay.BodyMap) (wxRsp *PrepayRsp
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("combine_appid") == util.NULL {
+		if bm.GetString("combine_appid") == util.NULL {
 			bm.Set("combine_appid", c.Appid)
 		}
-		if bm.Get("combine_mchid") == util.NULL {
+		if bm.GetString("combine_mchid") == util.NULL {
 			bm.Set("combine_mchid", c.Mchid)
 		}
 	}
@@ -489,10 +489,10 @@ func (c *ClientV3) V3CombineTransactionNative(bm gopay.BodyMap) (wxRsp *NativeRs
 	ts := time.Now().Unix()
 	nonceStr := util.GetRandomString(32)
 	if bm != nil {
-		if bm.Get("combine_appid") == util.NULL {
+		if bm.GetString("combine_appid") == util.NULL {
 			bm.Set("combine_appid", c.Appid)
 		}
-		if bm.Get("combine_mchid") == util.NULL {
+		if bm.GetString("combine_mchid") == util.NULL {
 			bm.Set("combine_mchid", c.Mchid)
 		}
 	}
@@ -559,7 +559,7 @@ func (c *ClientV3) V3CombineTransactionCloseOrder(tradeNo string, bm gopay.BodyM
 		url      = fmt.Sprintf(v3CombineClose, tradeNo)
 	)
 	if bm != nil {
-		if bm.Get("combine_appid") == util.NULL {
+		if bm.GetString("combine_appid") == util.NULL {
 			bm.Set("combine_appid", c.Appid)
 		}
 	}

--- a/wechat/v3/pay_public_api.go
+++ b/wechat/v3/pay_public_api.go
@@ -2,12 +2,12 @@ package wechat
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
-	"errors"
 	"github.com/iGoogle-ink/gopay"
 	"github.com/iGoogle-ink/gopay/pkg/util"
 )


### PR DESCRIPTION
版本号：Release 1.5.29
发布时间：2021/02/23 21:32
修改记录：
   (1) 支付宝：重构 client.PostAliPayAPISelf()，具体参考 client_test.go 内的 TestClient_PostAliPayAPISelf() 方法
   (2) BodyMap：新增 bm.SetFormFile() 的部分方法，修改 bm.Get() 方法，新增bm.GetString() 方法
   (3) xHttp：更新 httpClient， httpClient.Type() 支持 TypeMultipartFormData 类型