### PR TITLE
 增加资金授权冻结接/发码 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ func main() {
 * 转账业务单据查询接口：client.FundTransCommonQuery()
 * 资金退回接口: client.FundTransRefund()
 * 资金授权冻结接口: client.FundAuthOrderFreeze()
+* 资金授权发码接口: client.FundAuthOrderVoucherCreate()
 * 现金红包无线支付接口: client.FundTransAppPay()
 * 换取授权访问令牌（获取access_token，user_id等信息）：client.SystemOauthToken()
 * 支付宝会员授权信息查询接口（App支付宝登录）：client.UserInfoShare()

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ func main() {
 * 支付宝资金账户资产查询接口：client.FundAccountQuery()
 * 转账业务单据查询接口：client.FundTransCommonQuery()
 * 资金退回接口: client.FundTransRefund()
+* 资金授权冻结接口: client.FundAuthOrderFreeze()
 * 现金红包无线支付接口: client.FundTransAppPay()
 * 换取授权访问令牌（获取access_token，user_id等信息）：client.SystemOauthToken()
 * 支付宝会员授权信息查询接口（App支付宝登录）：client.UserInfoShare()

--- a/alipay/funds_api.go
+++ b/alipay/funds_api.go
@@ -122,6 +122,29 @@ func (a *Client) FundTransRefund(bm gopay.BodyMap) (aliRsp *FundTransRefundRespo
 	return aliRsp, nil
 }
 
+// alipay.fund.auth.order.freeze(资金授权冻结接口)
+// 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.auth.order.freeze
+func (a *Client) FundAuthOrderFreeze(bm gopay.BodyMap) (aliRsp *FundAuthOrderFreezeResponse, err error) {
+	err = bm.CheckEmptyError("auth_code", "auth_code_type", "out_order_no", "out_request_no", "order_title", "amount")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "alipay.fund.auth.order.freeze"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(FundAuthOrderFreezeResponse)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	aliRsp.SignData = getSignData(bs)
+	return aliRsp, nil
+}
+
 // alipay.fund.trans.app.pay(现金红包无线支付接口)
 // 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.app.pay
 func (a *Client) FundTransAppPay(bm gopay.BodyMap) (aliRsp *FundTransAppPayResponse, err error) {

--- a/alipay/funds_api.go
+++ b/alipay/funds_api.go
@@ -145,6 +145,29 @@ func (a *Client) FundAuthOrderFreeze(bm gopay.BodyMap) (aliRsp *FundAuthOrderFre
 	return aliRsp, nil
 }
 
+// alipay.fund.auth.order.voucher.create(资金授权发码接口)
+// 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.auth.order.voucher.create
+func (a *Client) FundAuthOrderVoucherCreate(bm gopay.BodyMap) (aliRsp *FundAuthOrderVoucherCreateResponse, err error) {
+	err = bm.CheckEmptyError("o,ut_order_no", "out_request_no", "order_title", "amount", "product_code")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "alipay.fund.auth.order.voucher.create"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(FundAuthOrderVoucherCreateResponse)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	aliRsp.SignData = getSignData(bs)
+	return aliRsp, nil
+}
+
 // alipay.fund.trans.app.pay(现金红包无线支付接口)
 // 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.app.pay
 func (a *Client) FundTransAppPay(bm gopay.BodyMap) (aliRsp *FundTransAppPayResponse, err error) {

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -552,6 +552,30 @@ type fundTransRefundResponse struct {
 }
 
 // ===================================================
+type FundAuthOrderFreezeResponse struct {
+	Response     *fundAuthOrderFreezeResponse `json:"alipay_fund_auth_order_freeze_response,omitempty"`
+	AlipayCertSn string                       `json:"alipay_cert_sn,omitempty"`
+	SignData     string                       `json:"-"`
+	Sign         string                       `json:"sign"`
+}
+
+type fundAuthOrderFreezeResponse struct {
+	Code         string `json:"code,omitempty"`
+	Msg          string `json:"msg,omitempty"`
+	SubCode      string `json:"sub_code,omitempty"`
+	SubMsg       string `json:"sub_msg,omitempty"`
+	AuthNo       string `json:"auth_no,omitempty"`
+	OutOrderNo   string `json:"out_order_no,omitempty"`
+	OperationId  string `json:"operation_id,omitempty"`
+	OutRequestNo string `json:"out_request_no,omitempty"`
+	Amount       string `json:"amount,omitempty"`
+	Status       string `json:"status,omitempty"`
+	PayerUserId  string `json:"payer_user_id,omitempty"`
+	PayerLogonId string `json:"payer_logon_id,omitempty"`
+	GmtTrans     string `json:"gmt_trans,omitempty"`
+}
+
+// ===================================================
 type FundTransAppPayResponse struct {
 	Response     *fundTransAppPayResponse `json:"alipay_fund_trans_app_pay_response,omitempty"`
 	AlipayCertSn string                   `json:"alipay_cert_sn,omitempty"`

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -576,6 +576,26 @@ type fundAuthOrderFreezeResponse struct {
 }
 
 // ===================================================
+type FundAuthOrderVoucherCreateResponse struct {
+	Response     *fundAuthOrderVoucherCreateResponse `json:"alipay_fund_auth_order_voucher_create_response,omitempty"`
+	AlipayCertSn string                              `json:"alipay_cert_sn,omitempty"`
+	SignData     string                              `json:"-"`
+	Sign         string                              `json:"sign"`
+}
+
+type fundAuthOrderVoucherCreateResponse struct {
+	Code         string `json:"code,omitempty"`
+	Msg          string `json:"msg,omitempty"`
+	SubCode      string `json:"sub_code,omitempty"`
+	SubMsg       string `json:"sub_msg,omitempty"`
+	OutOrderNo   string `json:"out_order_no,omitempty"`
+	OutRequestNo string `json:"out_request_no,omitempty"`
+	CodeType     string `json:"code_type,omitempty"`
+	CodeValue    string `json:"code_value,omitempty"`
+	CodeUrl      string `json:"code_url,omitempty"`
+}
+
+// ===================================================
 type FundTransAppPayResponse struct {
 	Response     *fundTransAppPayResponse `json:"alipay_fund_trans_app_pay_response,omitempty"`
 	AlipayCertSn string                   `json:"alipay_cert_sn,omitempty"`


### PR DESCRIPTION
增加两个支付宝资金类接口

+ 资金授权冻结接口: client.FundAuthOrderFreeze()
+ 资金授权发码接口: client.FundAuthOrderVoucherCreate()