### PR TITLE
增加资金授权撤销 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ func main() {
 * 资金授权操作查询接口: client.FundAuthOperationDetailQuery()
 * 资金授权撤销接口: client.FundAuthOperationCancel()
 * 批次下单接口: client.FundBatchCreate()
+* 批量转账关单接口: client.FundBatchClose()
 * 现金红包无线支付接口: client.FundTransAppPay()
 * 换取授权访问令牌（获取access_token，user_id等信息）：client.SystemOauthToken()
 * 支付宝会员授权信息查询接口（App支付宝登录）：client.UserInfoShare()

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ func main() {
 * 线上资金授权冻结接口: client:FundAuthOrderAppFreeze()
 * 资金授权解冻接口: client.FundAuthOrderUnfreeze()
 * 资金授权操作查询接口: client.FundAuthOperationDetailQuery()
+* 资金授权撤销接口: client.FundAuthOperationCancel()
 * 现金红包无线支付接口: client.FundTransAppPay()
 * 换取授权访问令牌（获取access_token，user_id等信息）：client.SystemOauthToken()
 * 支付宝会员授权信息查询接口（App支付宝登录）：client.UserInfoShare()

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ func main() {
 * 资金授权解冻接口: client.FundAuthOrderUnfreeze()
 * 资金授权操作查询接口: client.FundAuthOperationDetailQuery()
 * 资金授权撤销接口: client.FundAuthOperationCancel()
+* 批次下单接口: client.FundBatchCreate()
 * 现金红包无线支付接口: client.FundTransAppPay()
 * 换取授权访问令牌（获取access_token，user_id等信息）：client.SystemOauthToken()
 * 支付宝会员授权信息查询接口（App支付宝登录）：client.UserInfoShare()

--- a/alipay/funds_api.go
+++ b/alipay/funds_api.go
@@ -256,6 +256,29 @@ func (a *Client) FundAuthOperationCancel(bm gopay.BodyMap) (aliRsp *FundAuthOper
 	return aliRsp, nil
 }
 
+// alipay.fund.batch.create(批次下单接口)
+// 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.batch.create
+func (a *Client) FundBatchCreate(bm gopay.BodyMap) (aliRsp *FundBatchCreateResponse, err error) {
+	err = bm.CheckEmptyError("out_batch_no", "product_code", "biz_scene", "order_title", "total_trans_amount", "total_count", "trans_order_list")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "alipay.fund.batch.create"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(FundBatchCreateResponse)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	aliRsp.SignData = getSignData(bs)
+	return aliRsp, nil
+}
+
 // alipay.fund.trans.app.pay(现金红包无线支付接口)
 // 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.app.pay
 func (a *Client) FundTransAppPay(bm gopay.BodyMap) (aliRsp *FundTransAppPayResponse, err error) {

--- a/alipay/funds_api.go
+++ b/alipay/funds_api.go
@@ -233,6 +233,29 @@ func (a *Client) FundAuthOperationDetailQuery(bm gopay.BodyMap) (aliRsp *FundAut
 	return aliRsp, nil
 }
 
+// alipay.fund.auth.operation.cancel(资金授权撤销接口)
+// 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.auth.operation.cancel
+func (a *Client) FundAuthOperationCancel(bm gopay.BodyMap) (aliRsp *FundAuthOperationCancelResponse, err error) {
+	err = bm.CheckEmptyError("remark")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "alipay.fund.auth.operation.cancel"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(FundAuthOperationCancelResponse)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	aliRsp.SignData = getSignData(bs)
+	return aliRsp, nil
+}
+
 // alipay.fund.trans.app.pay(现金红包无线支付接口)
 // 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.app.pay
 func (a *Client) FundTransAppPay(bm gopay.BodyMap) (aliRsp *FundTransAppPayResponse, err error) {

--- a/alipay/funds_api.go
+++ b/alipay/funds_api.go
@@ -279,6 +279,29 @@ func (a *Client) FundBatchCreate(bm gopay.BodyMap) (aliRsp *FundBatchCreateRespo
 	return aliRsp, nil
 }
 
+// alipay.fund.batch.close(批量转账关单接口)
+// 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.batch.close
+func (a *Client) FundBatchClose(bm gopay.BodyMap) (aliRsp *FundBatchCloseResponse, err error) {
+	err = bm.CheckEmptyError("biz_scene")
+	if err != nil {
+		return nil, err
+	}
+	var bs []byte
+	if bs, err = a.doAliPay(bm, "alipay.fund.batch.close"); err != nil {
+		return nil, err
+	}
+	aliRsp = new(FundBatchCloseResponse)
+	if err = json.Unmarshal(bs, aliRsp); err != nil {
+		return nil, err
+	}
+	if aliRsp.Response != nil && aliRsp.Response.Code != "10000" {
+		info := aliRsp.Response
+		return nil, fmt.Errorf(`{"code":"%s","msg":"%s","sub_code":"%s","sub_msg":"%s"}`, info.Code, info.Msg, info.SubCode, info.SubMsg)
+	}
+	aliRsp.SignData = getSignData(bs)
+	return aliRsp, nil
+}
+
 // alipay.fund.trans.app.pay(现金红包无线支付接口)
 // 文档地址: https://opendocs.alipay.com/apis/api_28/alipay.fund.trans.app.pay
 func (a *Client) FundTransAppPay(bm gopay.BodyMap) (aliRsp *FundTransAppPayResponse, err error) {

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -689,6 +689,26 @@ type fundAuthOperationDetailQueryResponse struct {
 }
 
 // ===================================================
+type FundAuthOperationCancelResponse struct {
+	Response     *fundAuthOperationCancelResponse `json:"alipay_fund_auth_operation_cancel_response,omitempty"`
+	AlipayCertSn string                           `json:"alipay_cert_sn,omitempty"`
+	SignData     string                           `json:"-"`
+	Sign         string                           `json:"sign"`
+}
+
+type fundAuthOperationCancelResponse struct {
+	Code         string `json:"code,omitempty"`
+	Msg          string `json:"msg,omitempty"`
+	SubCode      string `json:"sub_code,omitempty"`
+	SubMsg       string `json:"sub_msg,omitempty"`
+	AuthNo       string `json:"auth_no,omitempty"`
+	OutOrderNo   string `json:"out_order_no,omitempty"`
+	OperationId  string `json:"operation_id,omitempty"`
+	OutRequestNo string `json:"out_request_no,omitempty"`
+	Action       string `json:"action,omitempty"`
+}
+
+// ===================================================
 type FundTransAppPayResponse struct {
 	Response     *fundTransAppPayResponse `json:"alipay_fund_trans_app_pay_response,omitempty"`
 	AlipayCertSn string                   `json:"alipay_cert_sn,omitempty"`

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -727,6 +727,23 @@ type fundBatchCreateResponse struct {
 }
 
 // ===================================================
+type FundBatchCloseResponse struct {
+	Response     *fundBatchCloseResponse `json:"alipay_fund_batch_close_response,omitempty"`
+	AlipayCertSn string                  `json:"alipay_cert_sn,omitempty"`
+	SignData     string                  `json:"-"`
+	Sign         string                  `json:"sign"`
+}
+
+type fundBatchCloseResponse struct {
+	Code         string `json:"code,omitempty"`
+	Msg          string `json:"msg,omitempty"`
+	SubCode      string `json:"sub_code,omitempty"`
+	SubMsg       string `json:"sub_msg,omitempty"`
+	BatchTransId string `json:"batch_trans_id,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+// ===================================================
 type FundTransAppPayResponse struct {
 	Response     *fundTransAppPayResponse `json:"alipay_fund_trans_app_pay_response,omitempty"`
 	AlipayCertSn string                   `json:"alipay_cert_sn,omitempty"`

--- a/alipay/model.go
+++ b/alipay/model.go
@@ -709,6 +709,24 @@ type fundAuthOperationCancelResponse struct {
 }
 
 // ===================================================
+type FundBatchCreateResponse struct {
+	Response     *fundBatchCreateResponse `json:"alipay_fund_batch_create_response,omitempty"`
+	AlipayCertSn string                   `json:"alipay_cert_sn,omitempty"`
+	SignData     string                   `json:"-"`
+	Sign         string                   `json:"sign"`
+}
+
+type fundBatchCreateResponse struct {
+	Code         string `json:"code,omitempty"`
+	Msg          string `json:"msg,omitempty"`
+	SubCode      string `json:"sub_code,omitempty"`
+	SubMsg       string `json:"sub_msg,omitempty"`
+	OutBatchNo   string `json:"out_batch_no,omitempty"`
+	BatchTransId string `json:"batch_trans_id,omitempty"`
+	Status       string `json:"status,omitempty"`
+}
+
+// ===================================================
 type FundTransAppPayResponse struct {
 	Response     *fundTransAppPayResponse `json:"alipay_fund_trans_app_pay_response,omitempty"`
 	AlipayCertSn string                   `json:"alipay_cert_sn,omitempty"`


### PR DESCRIPTION
 增加三个支付宝资金类接口
+ 资金授权撤销
+ 批次下单
+ 批量转账关单