### PR TITLE
Wechat/remove method cert param

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/iGoogle-ink/gopay)](https://github.com/iGoogle-ink/gopay/releases)
 [![License](https://img.shields.io/github/license/iGoogle-ink/gopay)](https://www.apache.org/licenses/LICENSE-2.0)
 
---- 
-
-## ★招聘广告★：
-
-有意向的请直接加我微信（文档说明处有我的微信二维码）
-
-- 公司：上海商米科技集团股份有限公司
-- 要求：3-5年后端工程师（Golang）
-- 地点：上海市杨浦区五角场
-
---- 
+---
 
 # 一、安装
 
@@ -301,7 +291,7 @@ client.DebugSwitch = gopay.DebugOff
 
 > 注意：微信支付下单等操作可用沙箱环境测试是否成功，但真正支付时，请使用正式环境 isProd = true，不然会报错。
 
-> 微信证书现已支持二选一：只传 apiclient_cert.pem 和 apiclient_key.pem 或者只传 apiclient_cert.p12
+> 微信证书二选一：只传 apiclient_cert.pem 和 apiclient_key.pem 或者只传 apiclient_cert.p12
 
 ```go
 import (
@@ -325,17 +315,12 @@ client.DebugSwitch = gopay.DebugOn
 //    wechat.Other：其他国家
 client.SetCountry(wechat.China)
 
-// 添加微信证书文件 Path 路径或证书内容
-//	  注意：只传pem证书或只传pkcs12证书均可，无需3个证书全传
-//	  certFilePath：apiclient_cert.pem 路径或内容
-//	  keyFilePath：apiclient_key.pem 路径或内容
-//	  pkcs12FilePath：apiclient_cert.p12 路径或内容
-client.AddCertFilePath()
-
-// 添加微信pem证书内容或证书文件Path
+// 添加微信pem证书
+client.AddCertPemFilePath()
 client.AddCertPemFileContent()
 
-// 添加微信pkcs12证书内容证书文件Path
+// 添加微信pkcs12证书
+client.AddCertPkcs12FilePath()
 client.AddCertPkcs12FileContent()
 ```
 
@@ -471,13 +456,13 @@ wxRsp, err := client.UnifiedOrder(bm)
 wxRsp, err := client.Micropay(bm)
 wxRsp, err := client.QueryOrder(bm)
 wxRsp, err := client.CloseOrder(bm)
-wxRsp, err := client.Reverse(bm, "apiclient_cert.pem", "apiclient_key.pem", "apiclient_cert.p12")
-wxRsp, err := client.Refund(bm, "apiclient_cert.pem", "apiclient_key.pem", "apiclient_cert.p12")
+wxRsp, err := client.Reverse(bm)
+wxRsp, err := client.Refund(bm)
 wxRsp, err := client.QueryRefund(bm)
 wxRsp, err := client.DownloadBill(bm)
-wxRsp, err := client.DownloadFundFlow(bm, "apiclient_cert.pem", "apiclient_key.pem", "apiclient_cert.p12")
-wxRsp, err := client.BatchQueryComment(bm, "apiclient_cert.pem", "apiclient_key.pem", "apiclient_cert.p12")
-wxRsp, err := client.Transfer(bm, "apiclient_cert.pem", "apiclient_key.pem", "apiclient_cert.p12")
+wxRsp, err := client.DownloadFundFlow(bm)
+wxRsp, err := client.BatchQueryComment(bm)
+wxRsp, err := client.Transfer(bm)
 ```
 
 * #### 支付宝 client

--- a/README.md
+++ b/README.md
@@ -325,19 +325,18 @@ client.DebugSwitch = gopay.DebugOn
 //    wechat.Other：其他国家
 client.SetCountry(wechat.China)
 
-// 添加微信证书 Path 路径
-//    certFilePath：apiclient_cert.pem 路径
-//    keyFilePath：apiclient_key.pem 路径
-//    pkcs12FilePath：apiclient_cert.p12 路径
-//    返回err
+// 添加微信证书文件 Path 路径或证书内容
+//	  注意：只传pem证书或只传pkcs12证书均可，无需3个证书全传
+//	  certFilePath：apiclient_cert.pem 路径或内容
+//	  keyFilePath：apiclient_key.pem 路径或内容
+//	  pkcs12FilePath：apiclient_cert.p12 路径或内容
 client.AddCertFilePath()
 
-// 添加微信证书内容 Content
-//	certFileContent：apiclient_cert.pem 内容
-//	keyFileContent：apiclient_key.pem 内容
-//	pkcs12FileContent：apiclient_cert.p12 内容
-//	返回err
-client.AddCertFileContent()
+// 添加微信pem证书内容或证书文件Path
+client.AddCertPemFileContent()
+
+// 添加微信pkcs12证书内容证书文件Path
+client.AddCertPkcs12FileContent()
 ```
 
 * #### 支付宝

--- a/constant.go
+++ b/constant.go
@@ -7,7 +7,7 @@ const (
 	OK       = "OK"
 	DebugOff = 0
 	DebugOn  = 1
-	Version  = "1.5.37"
+	Version  = "1.5.38"
 )
 
 type DebugSwitch int8

--- a/examples/wechat/wx_BatchQueryComment.go
+++ b/examples/wechat/wx_BatchQueryComment.go
@@ -26,7 +26,7 @@ func BatchQueryComment() {
 		Set("offset", "0")
 
 	// 请求拉取订单评价数据，成功后得到结果，沙箱环境下，证书路径参数可传空
-	wxRsp, err := client.BatchQueryComment(bm, nil, nil, nil)
+	wxRsp, err := client.BatchQueryComment(bm)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/examples/wechat/wx_DownloadFundFlow.go
+++ b/examples/wechat/wx_DownloadFundFlow.go
@@ -25,7 +25,7 @@ func DownloadFundFlow() {
 		Set("account_type", "Basic")
 
 	// 请求下载资金账单，成功后得到结果，沙箱环境下，证书路径参数可传空
-	wxRsp, err := client.DownloadFundFlow(bm, nil, nil, nil)
+	wxRsp, err := client.DownloadFundFlow(bm)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/examples/wechat/wx_Refund.go
+++ b/examples/wechat/wx_Refund.go
@@ -33,7 +33,7 @@ func Refund() {
 	//    certFilePath：cert证书路径
 	//    keyFilePath：Key证书路径
 	//    pkcs12FilePath：p12证书路径
-	wxRsp, resBm, err := client.Refund(bm, "iguiyu_cert/apiclient_cert.pem", "iguiyu_cert/apiclient_key.pem", "iguiyu_cert/apiclient_cert.p12")
+	wxRsp, resBm, err := client.Refund(bm)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/examples/wechat/wx_Reverse.go
+++ b/examples/wechat/wx_Reverse.go
@@ -23,7 +23,7 @@ func Reverse() {
 		Set("sign_type", wechat.SignType_MD5)
 
 	//请求撤销订单，成功后得到结果，沙箱环境下，证书路径参数可传空
-	wxRsp, err := client.Reverse(bm, nil, nil, nil)
+	wxRsp, err := client.Reverse(bm)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/examples/wechat/wx_Transfer.go
+++ b/examples/wechat/wx_Transfer.go
@@ -38,7 +38,7 @@ func Transfer() {
 	//    certFilePath：cert证书路径
 	//    keyFilePath：Key证书路径
 	//    pkcs12FilePath：p12证书路径
-	wxRsp, err := client.Transfer(bm, nil, nil, nil)
+	wxRsp, err := client.Transfer(bm)
 	if err != nil {
 		xlog.Error(err)
 		return

--- a/release_note.txt
+++ b/release_note.txt
@@ -1,3 +1,8 @@
+版本号：Release 1.5.38
+修改记录：
+   (1) 微信：去掉所以微信 client 方法中需要传证书的参数，请统一在初始化client时，添加证书
+   (2) 微信：使用方法请参考 wechat/client_test.go 下的初始化，以及各个方法使用
+
 版本号：Release 1.5.37
 修改记录：
    (1) 支付宝：修改 client.FundAuthOrderAppFreeze() 接口返回参数

--- a/wechat/base_api.go
+++ b/wechat/base_api.go
@@ -112,12 +112,9 @@ func (w *Client) CloseOrder(bm gopay.BodyMap) (wxRsp *CloseOrderResponse, err er
 }
 
 // 申请退款
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/open/chapter3_4.shtml
-func (w *Client) Refund(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *RefundResponse, resBm gopay.BodyMap, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, nil, err
-	}
+func (w *Client) Refund(bm gopay.BodyMap) (wxRsp *RefundResponse, resBm gopay.BodyMap, err error) {
 	err = bm.CheckEmptyError("nonce_str", "out_refund_no", "total_fee", "refund_fee")
 	if err != nil {
 		return nil, nil, err
@@ -130,7 +127,7 @@ func (w *Client) Refund(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FileP
 		tlsConfig *tls.Config
 	)
 	if w.IsProd {
-		if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+		if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 			return nil, nil, err
 		}
 		bs, err = w.doProdPost(bm, refund, tlsConfig)
@@ -182,12 +179,9 @@ func (w *Client) QueryRefund(bm gopay.BodyMap) (wxRsp *QueryRefundResponse, resB
 }
 
 // 撤销订单
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/open/chapter4_3.shtml
-func (w *Client) Reverse(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *ReverseResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) Reverse(bm gopay.BodyMap) (wxRsp *ReverseResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "out_trade_no")
 	if err != nil {
 		return nil, err
@@ -197,7 +191,7 @@ func (w *Client) Reverse(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12File
 		tlsConfig *tls.Config
 	)
 	if w.IsProd {
-		if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+		if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 			return nil, err
 		}
 		bs, err = w.doProdPost(bm, reverse, tlsConfig)

--- a/wechat/base_api_test.go
+++ b/wechat/base_api_test.go
@@ -136,7 +136,7 @@ func TestClient_Refund(t *testing.T) {
 	//    certFilePath：cert证书路径
 	//    keyFilePath：Key证书路径
 	//    pkcs12FilePath：p12证书路径
-	wxRsp, resBm, err := client.Refund(bm, nil, nil, nil)
+	wxRsp, resBm, err := client.Refund(bm)
 	if err != nil {
 		xlog.Errorf("client.Refund(%+v),error:%+v", bm, err)
 		return
@@ -173,7 +173,7 @@ func TestClient_Reverse(t *testing.T) {
 		Set("sign_type", SignType_MD5)
 
 	// 请求撤销订单，成功后得到结果，沙箱环境下，证书路径参数可传nil
-	wxRsp, err := client.Reverse(bm, nil, nil, nil)
+	wxRsp, err := client.Reverse(bm)
 	if err != nil {
 		xlog.Errorf("client.Reverse(%+v),error:%+v", bm, err)
 		return

--- a/wechat/client.go
+++ b/wechat/client.go
@@ -92,13 +92,10 @@ func (w *Client) DownloadBill(bm gopay.BodyMap) (wxRsp string, err error) {
 }
 
 // 下载资金账单（正式）
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
-//	貌似不支持沙箱环境，因为沙箱环境默认需要用MD5签名，但是此接口仅支持HMAC-SHA256签名
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
+//	不支持沙箱环境，因为沙箱环境默认需要用MD5签名，但是此接口仅支持HMAC-SHA256签名
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/open/chapter3_7.shtml
-func (w *Client) DownloadFundFlow(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp string, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return util.NULL, err
-	}
+func (w *Client) DownloadFundFlow(bm gopay.BodyMap) (wxRsp string, err error) {
 	err = bm.CheckEmptyError("nonce_str", "bill_date", "account_type")
 	if err != nil {
 		return util.NULL, err
@@ -108,7 +105,7 @@ func (w *Client) DownloadFundFlow(bm gopay.BodyMap, certFilePath, keyFilePath, p
 		return util.NULL, errors.New("account_type error, please reference: https://pay.weixin.qq.com/wiki/doc/api/jsapi.php?chapter=9_18&index=7")
 	}
 	bm.Set("sign_type", SignType_HMAC_SHA256)
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return util.NULL, err
 	}
@@ -149,19 +146,16 @@ func (w *Client) Report(bm gopay.BodyMap) (wxRsp *ReportResponse, err error) {
 }
 
 // 拉取订单评价数据（正式）
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
-//	貌似不支持沙箱环境，因为沙箱环境默认需要用MD5签名，但是此接口仅支持HMAC-SHA256签名
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
+//	不支持沙箱环境，因为沙箱环境默认需要用MD5签名，但是此接口仅支持HMAC-SHA256签名
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/wxpay_v2/open/chapter3_11.shtml
-func (w *Client) BatchQueryComment(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp string, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return util.NULL, err
-	}
+func (w *Client) BatchQueryComment(bm gopay.BodyMap) (wxRsp string, err error) {
 	err = bm.CheckEmptyError("nonce_str", "begin_time", "end_time", "offset")
 	if err != nil {
 		return util.NULL, err
 	}
 	bm.Set("sign_type", SignType_HMAC_SHA256)
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return util.NULL, err
 	}

--- a/wechat/client_test.go
+++ b/wechat/client_test.go
@@ -31,16 +31,17 @@ func TestMain(m *testing.M) {
 	// 设置国家，不设置默认就是 China
 	client.SetCountry(China)
 
-	// 注意：证书内容只添加pem或只添加pkcs12均可
-
-	// 添加pem证书内容
-	//err := client.AddCertPemFileContent(nil, nil)
+	// 不使用证书接口，可以不添加证书
+	// 添加pkcs12内容
+	//err = client.AddCertPkcs12FilePath("apiclient_cert.p12")
 	//if err != nil {
 	//	panic(err)
 	//}
 
-	// 或添加pkcs12内容
-	//err := client.AddCertPkcs12FileContent(nil)
+	// 或
+
+	// 添加pem证书路径
+	//err := client.AddCertPemFilePath("apiclient_cert.pem", "apiclient_key.pem")
 	//if err != nil {
 	//	panic(err)
 	//}
@@ -73,7 +74,7 @@ func TestClient_GetTransferInfo(t *testing.T) {
 	//    certFilePath：cert证书路径
 	//    keyFilePath：Key证书路径
 	//    pkcs12FilePath：p12证书路径
-	wxRsp, err := client.GetTransferInfo(bm, nil, nil, nil)
+	wxRsp, err := client.GetTransferInfo(bm)
 	if err != nil {
 		xlog.Errorf("client.GetTransferInfo(%+v),error:%+v", bm, err)
 		return
@@ -107,7 +108,7 @@ func TestClient_DownloadFundFlow(t *testing.T) {
 		Set("account_type", "Basic")
 
 	// 请求下载资金账单，成功后得到结果，沙箱环境下，证书路径参数可传nil
-	wxRsp, err := client.DownloadFundFlow(bm, nil, nil, nil)
+	wxRsp, err := client.DownloadFundFlow(bm)
 	if err != nil {
 		xlog.Errorf("client.DownloadFundFlow(%+v),error:%+v", bm, err)
 		return
@@ -125,7 +126,7 @@ func TestClient_BatchQueryComment(t *testing.T) {
 		Set("offset", "0")
 
 	// 请求拉取订单评价数据，成功后得到结果，沙箱环境下，证书路径参数可传nil
-	wxRsp, err := client.BatchQueryComment(bm, nil, nil, nil)
+	wxRsp, err := client.BatchQueryComment(bm)
 	if err != nil {
 		xlog.Errorf("client.BatchQueryComment(%+v),error:%+v", bm, err)
 		return

--- a/wechat/client_test.go
+++ b/wechat/client_test.go
@@ -31,14 +31,16 @@ func TestMain(m *testing.M) {
 	// 设置国家，不设置默认就是 China
 	client.SetCountry(China)
 
-	// 添加证书n内容
-	//err := client.AddCertFileContent(nil, nil, nil)
+	// 注意：证书内容只添加pem或只添加pkcs12均可
+
+	// 添加pem证书内容
+	//err := client.AddCertPemFileContent(nil, nil)
 	//if err != nil {
 	//	panic(err)
 	//}
 
-	// 添加证书路径
-	//err := client.AddCertFilePath(nil, nil, nil)
+	// 或添加pkcs12内容
+	//err := client.AddCertPkcs12FileContent(nil)
 	//if err != nil {
 	//	panic(err)
 	//}

--- a/wechat/merchant.go
+++ b/wechat/merchant.go
@@ -13,13 +13,11 @@ import (
 )
 
 // 企业付款（企业向微信用户个人付款）
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则3证书Path均不可为nil（string类型）
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此方法未支持沙箱环境，默认正式环境，转账请慎重
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=14_2
-func (w *Client) Transfer(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *TransfersResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) Transfer(bm gopay.BodyMap) (wxRsp *TransfersResponse, err error) {
+
 	if err = bm.CheckEmptyError("nonce_str", "partner_trade_no", "openid", "check_name", "amount", "desc", "spbill_create_ip"); err != nil {
 		return nil, err
 	}
@@ -29,7 +27,7 @@ func (w *Client) Transfer(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12Fil
 		tlsConfig *tls.Config
 		url       = baseUrlCh + transfers
 	)
-	if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+	if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 		return nil, err
 	}
 	bm.Set("sign", getReleaseSign(w.ApiKey, SignType_MD5, bm))
@@ -62,13 +60,10 @@ func (w *Client) Transfer(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12Fil
 }
 
 // 查询企业付款
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则3证书Path均不可为nil（string类型）
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此方法未支持沙箱环境，默认正式环境
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=14_3
-func (w *Client) GetTransferInfo(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *TransfersInfoResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) GetTransferInfo(bm gopay.BodyMap) (wxRsp *TransfersInfoResponse, err error) {
 	if err = bm.CheckEmptyError("nonce_str", "partner_trade_no"); err != nil {
 		return nil, err
 	}
@@ -78,7 +73,7 @@ func (w *Client) GetTransferInfo(bm gopay.BodyMap, certFilePath, keyFilePath, pk
 		tlsConfig *tls.Config
 		url       = baseUrlCh + getTransferInfo
 	)
-	if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+	if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 		return nil, err
 	}
 	bm.Set("sign", getReleaseSign(w.ApiKey, SignType_MD5, bm))
@@ -110,17 +105,14 @@ func (w *Client) GetTransferInfo(bm gopay.BodyMap, certFilePath, keyFilePath, pk
 	return wxRsp, nil
 }
 
-// 企业付款到银行卡API
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则3证书Path均不可为nil（string类型）
+// 企业付款到银行卡API（正式）
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此方法未支持沙箱环境，默认正式环境，转账请慎重
 //	注意：enc_bank_no、enc_true_name 两参数，开发者需自行获取RSA公钥，加密后再 Set 到 BodyMap，参考 client_test.go 里的 TestClient_PayBank() 方法
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=24_2
 //	RSA加密文档地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=24_7
 //	银行编码查看地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=24_4&index=5
-func (w *Client) PayBank(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *PayBankResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) PayBank(bm gopay.BodyMap) (wxRsp *PayBankResponse, err error) {
 	if err = bm.CheckEmptyError("partner_trade_no", "nonce_str", "enc_bank_no", "enc_true_name", "bank_code", "amount"); err != nil {
 		return nil, err
 	}
@@ -129,7 +121,7 @@ func (w *Client) PayBank(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12File
 		tlsConfig *tls.Config
 		url       = baseUrlCh + payBank
 	)
-	if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+	if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 		return nil, err
 	}
 	bm.Set("sign", getReleaseSign(w.ApiKey, SignType_MD5, bm))
@@ -161,14 +153,10 @@ func (w *Client) PayBank(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12File
 	return wxRsp, nil
 }
 
-// 查询企业付款到银行卡API
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则3证书Path均不可为nil（string类型）
-//	注意：此方法未支持沙箱环境，默认正式环境
+// 查询企业付款到银行卡API（正式）
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=24_3
-func (w *Client) QueryBank(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *QueryBankResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) QueryBank(bm gopay.BodyMap) (wxRsp *QueryBankResponse, err error) {
 	if err = bm.CheckEmptyError("nonce_str", "partner_trade_no"); err != nil {
 		return nil, err
 	}
@@ -177,7 +165,7 @@ func (w *Client) QueryBank(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12Fi
 		tlsConfig *tls.Config
 		url       = baseUrlCh + queryBank
 	)
-	if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+	if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 		return nil, err
 	}
 	bm.Set("sign", getReleaseSign(w.ApiKey, SignType_MD5, bm))
@@ -209,14 +197,10 @@ func (w *Client) QueryBank(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12Fi
 	return wxRsp, nil
 }
 
-// 获取RSA加密公钥API
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则3证书Path均不可为nil（string类型）
-//	注意：此方法未支持沙箱环境，默认正式环境
+// 获取RSA加密公钥API（正式）
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/tools/mch_pay.php?chapter=24_7&index=4
-func (w *Client) GetRSAPublicKey(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *RSAPublicKeyResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) GetRSAPublicKey(bm gopay.BodyMap) (wxRsp *RSAPublicKeyResponse, err error) {
 	if err = bm.CheckEmptyError("nonce_str", "sign_type"); err != nil {
 		return nil, err
 	}
@@ -225,7 +209,7 @@ func (w *Client) GetRSAPublicKey(bm gopay.BodyMap, certFilePath, keyFilePath, pk
 		tlsConfig *tls.Config
 		url       = getPublicKey
 	)
-	if tlsConfig, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+	if tlsConfig, err = w.addCertConfig(nil, nil, nil); err != nil {
 		return nil, err
 	}
 	bm.Set("sign", getReleaseSign(w.ApiKey, bm.GetString("sign_type"), bm))
@@ -252,31 +236,28 @@ func (w *Client) GetRSAPublicKey(bm gopay.BodyMap, certFilePath, keyFilePath, pk
 	return wxRsp, nil
 }
 
-// ProfitSharing 请求单次分账
+// 请求单次分账
 //	单次分账请求按照传入的分账接收方账号和资金进行分账，
 //	同时会将订单剩余的待分账金额解冻给本商户。
 //	故操作成功后，订单不能再进行分账，也不能进行分账完结。
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_1&index=1
-func (w *Client) ProfitSharing(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *ProfitSharingResponse, err error) {
-	return w.profitSharing(bm, profitSharing, certFilePath, keyFilePath, pkcs12FilePath)
+func (w *Client) ProfitSharing(bm gopay.BodyMap) (wxRsp *ProfitSharingResponse, err error) {
+	return w.profitSharing(bm, profitSharing)
 }
 
-// MultiProfitSharing 请求多次分账
+// 请求多次分账
 //	微信订单支付成功后，商户发起分账请求，将结算后的钱分到分账接收方。多次分账请求仅会按照传入的分账接收方进行分账，不会对剩余的金额进行任何操作。
 //	故操作成功后，在待分账金额不等于零时，订单依旧能够再次进行分账。
 //	多次分账，可以将本商户作为分账接收方直接传入，实现释放资金给本商户的功能
 //	对同一笔订单最多能发起20次多次分账请求
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	文档地址：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_1&index=1
-func (w *Client) MultiProfitSharing(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *ProfitSharingResponse, err error) {
-	return w.profitSharing(bm, multiProfitSharing, certFilePath, keyFilePath, pkcs12FilePath)
+func (w *Client) MultiProfitSharing(bm gopay.BodyMap) (wxRsp *ProfitSharingResponse, err error) {
+	return w.profitSharing(bm, multiProfitSharing)
 }
 
-func (w *Client) profitSharing(bm gopay.BodyMap, uri string, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *ProfitSharingResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) profitSharing(bm gopay.BodyMap, uri string) (wxRsp *ProfitSharingResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "transaction_id", "out_order_no", "receivers")
 	if err != nil {
 		return nil, err
@@ -284,7 +265,7 @@ func (w *Client) profitSharing(bm gopay.BodyMap, uri string, certFilePath, keyFi
 
 	// 设置签名类型，官方文档此接口只支持 HMAC_SHA256
 	bm.Set("sign_type", SignType_HMAC_SHA256)
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -299,9 +280,8 @@ func (w *Client) profitSharing(bm gopay.BodyMap, uri string, certFilePath, keyFi
 	return wxRsp, nil
 }
 
-// ProfitSharingQuery 查询分账结果
+// 查询分账结果
 //	发起分账请求后，可调用此接口查询分账结果；发起分账完结请求后，可调用此接口查询分账完结的执行结果。
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_2&index=3
 func (w *Client) ProfitSharingQuery(bm gopay.BodyMap) (wxRsp *ProfitSharingQueryResponse, err error) {
 	err = bm.CheckEmptyError("transaction_id", "out_order_no", "nonce_str")
@@ -326,9 +306,8 @@ func (w *Client) ProfitSharingQuery(bm gopay.BodyMap) (wxRsp *ProfitSharingQuery
 	return wxRsp, nil
 }
 
-// ProfitSharingAddReceiver 添加分账接收方
+// 添加分账接收方
 //	商户发起添加分账接收方请求，后续可通过发起分账请求将结算后的钱分到该分账接收方。
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_3&index=4
 func (w *Client) ProfitSharingAddReceiver(bm gopay.BodyMap) (wxRsp *ProfitSharingAddReceiverResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "receiver")
@@ -348,9 +327,8 @@ func (w *Client) ProfitSharingAddReceiver(bm gopay.BodyMap) (wxRsp *ProfitSharin
 	return wxRsp, nil
 }
 
-// ProfitSharingRemoveReceiver 删除分账接收方
+// 删除分账接收方
 //	商户发起删除分账接收方请求，删除后不支持将结算后的钱分到该分账接收方
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_4&index=5
 func (w *Client) ProfitSharingRemoveReceiver(bm gopay.BodyMap) (wxRsp *ProfitSharingAddReceiverResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "receiver")
@@ -370,23 +348,20 @@ func (w *Client) ProfitSharingRemoveReceiver(bm gopay.BodyMap) (wxRsp *ProfitSha
 	return wxRsp, nil
 }
 
-// ProfitSharingFinish 完结分账
+// 完结分账
 //	1、不需要进行分账的订单，可直接调用本接口将订单的金额全部解冻给本商户
 //	2、调用多次分账接口后，需要解冻剩余资金时，调用本接口将剩余的分账金额全部解冻给特约商户
 //	3、已调用请求单次分账后，剩余待分账金额为零，不需要再调用此接口。
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_5&index=6
-func (w *Client) ProfitSharingFinish(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *ProfitSharingResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) ProfitSharingFinish(bm gopay.BodyMap) (wxRsp *ProfitSharingResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "transaction_id", "out_order_no", "description")
 	if err != nil {
 		return nil, err
 	}
 	// 设置签名类型，官方文档此接口只支持 HMAC_SHA256
 	bm.Set("sign_type", SignType_HMAC_SHA256)
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -401,17 +376,14 @@ func (w *Client) ProfitSharingFinish(bm gopay.BodyMap, certFilePath, keyFilePath
 	return wxRsp, nil
 }
 
-// ProfitSharingReturn 分账回退
+// 分账回退
 //	对订单进行退款时，如果订单已经分账，可以先调用此接口将指定的金额从分账接收方（仅限商户类型的分账接收方）回退给本商户，然后再退款。
 //	回退以原分账请求为依据，可以对分给分账接收方的金额进行多次回退，只要满足累计回退不超过该请求中分给接收方的金额。
 //	此接口采用同步处理模式，即在接收到商户请求后，会实时返回处理结果
 //	此功能需要接收方在商户平台-交易中心-分账-分账接收设置下，开启同意分账回退后，才能使用。
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_7&index=7
-func (w *Client) ProfitSharingReturn(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *ProfitSharingReturnResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) ProfitSharingReturn(bm gopay.BodyMap) (wxRsp *ProfitSharingReturnResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "out_return_no", "return_account_type", "return_account", "return_amount", "description")
 	if err != nil {
 		return nil, err
@@ -422,7 +394,7 @@ func (w *Client) ProfitSharingReturn(bm gopay.BodyMap, certFilePath, keyFilePath
 	}
 	// 设置签名类型，官方文档此接口只支持 HMAC_SHA256
 	bm.Set("sign_type", SignType_HMAC_SHA256)
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -437,10 +409,9 @@ func (w *Client) ProfitSharingReturn(bm gopay.BodyMap, certFilePath, keyFilePath
 	return wxRsp, nil
 }
 
-// ProfitSharingReturnQuery 回退结果查询
+// 回退结果查询
 //	商户需要核实回退结果，可调用此接口查询回退结果。
 //	如果分账回退接口返回状态为处理中，可调用此接口查询回退结果
-//	注意：如已使用client.AddCertFilePath()或client.AddCertFileContent()添加过证书，参数certFilePath、keyFilePath、pkcs12FilePath全传 nil，否则，3证书Path均不可空
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/allocation.php?chapter=27_8&index=8
 func (w *Client) ProfitSharingReturnQuery(bm gopay.BodyMap) (wxRsp *ProfitSharingReturnResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "out_return_no")

--- a/wechat/merchant_test.go
+++ b/wechat/merchant_test.go
@@ -28,7 +28,7 @@ func TestClient_Transfer(t *testing.T) {
 	//    certFilePath：cert证书路径
 	//    keyFilePath：Key证书路径
 	//    pkcs12FilePath：p12证书路径
-	wxRsp, err := client.Transfer(bm, nil, nil, nil)
+	wxRsp, err := client.Transfer(bm)
 	if err != nil {
 		xlog.Errorf("client.Transfer(%+v),error:%+v", bm, err)
 		return
@@ -69,7 +69,7 @@ func Test_ProfitSharing(t *testing.T) {
 
 	bm.Set("receivers", string(bs))
 
-	wxRsp, err := client.ProfitSharing(bm, nil, nil, nil)
+	wxRsp, err := client.ProfitSharing(bm)
 	if err != nil {
 		xlog.Errorf("client.ProfitSharingAddReceiver(%+v),error:%+v", bm, err)
 		return
@@ -121,7 +121,7 @@ func TestClient_GetRSAPublicKey(t *testing.T) {
 	bm := make(gopay.BodyMap)
 	bm.Set("nonce_str", util.GetRandomString(32)).
 		Set("sign_type", SignType_MD5)
-	publicKey, err := client.GetRSAPublicKey(bm, nil, nil, nil)
+	publicKey, err := client.GetRSAPublicKey(bm)
 	if err != nil {
 		xlog.Error(err)
 		return
@@ -151,7 +151,7 @@ func TestClient_PayBank(t *testing.T) {
 		Set("enc_true_name", encryptName)
 
 	// 企业付款到银行卡API
-	wxRsp, err := client.PayBank(bm, "certFilePath", "keyFilePath", "pkcs12FilePath")
+	wxRsp, err := client.PayBank(bm)
 	if err != nil {
 		xlog.Errorf("client.EntrustPaying(%+v),error:%+v", bm, err)
 		return

--- a/wechat/param.go
+++ b/wechat/param.go
@@ -43,10 +43,11 @@ func (w *Client) SetCountry(country Country) (client *Client) {
 	return w
 }
 
-// 添加微信证书 Path 路径
-//	certFilePath：apiclient_cert.pem 路径
-//	keyFilePath：apiclient_key.pem 路径
-//	pkcs12FilePath：apiclient_cert.p12 路径
+// 添加微信证书文件 Path 路径或证书内容
+//	注意：只传pem证书或只传pkcs12证书均可，无需3个证书全传
+//	certFilePath：apiclient_cert.pem 路径或内容
+//	keyFilePath：apiclient_key.pem 路径或内容
+//	pkcs12FilePath：apiclient_cert.p12 路径或内容
 //	返回err
 func (w *Client) AddCertFilePath(certFilePath, keyFilePath, pkcs12FilePath interface{}) (err error) {
 	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
@@ -62,6 +63,8 @@ func (w *Client) AddCertFilePath(certFilePath, keyFilePath, pkcs12FilePath inter
 	return
 }
 
+// Deprecated
+// 推荐使用 AddCertPemFileContent() 或 AddCertPkcs12FileContent()
 // 添加微信证书内容
 //	certFileContent：apiclient_cert.pem 内容
 //	keyFileContent：apiclient_key.pem 内容
@@ -71,12 +74,12 @@ func (w *Client) AddCertFileContent(certFileContent, keyFileContent, pkcs12FileC
 	return w.AddCertFilePath(certFileContent, keyFileContent, pkcs12FileContent)
 }
 
-// 添加微信pem证书内容
+// 添加微信pem证书内容或证书文件Path
 func (w *Client) AddCertPemFileContent(certFileContent, keyFileContent []byte) (err error) {
 	return w.AddCertFilePath(certFileContent, keyFileContent, nil)
 }
 
-// 添加微信pkcs12证书内容
+// 添加微信pkcs12证书内容证书文件Path
 func (w *Client) AddCertPkcs12FileContent(pkcs12FileContent []byte) (err error) {
 	return w.AddCertFilePath(nil, nil, pkcs12FileContent)
 }

--- a/wechat/param.go
+++ b/wechat/param.go
@@ -43,45 +43,54 @@ func (w *Client) SetCountry(country Country) (client *Client) {
 	return w
 }
 
+// Deprecated
+// 推荐使用 AddCertPemFileContent() 或 AddCertPemFilePath() 或 AddCertPkcs12FileContent() 或 AddCertPkcs12FilePath()
+// 添加微信证书路径或内容[]byte
+//	注意：只传pem证书或只传pkcs12证书均可，无需3个证书全传
+func (w *Client) AddCertFilePath(certFileContent, keyFileContent, pkcs12FileContent interface{}) (err error) {
+	return w.addCertFileContentOrPath(certFileContent, keyFileContent, pkcs12FileContent)
+}
+
+// 添加微信pem证书文件路径
+//	certFilePath：apiclient_cert.pem 文件路径
+//	keyFilePath：apiclient_key.pem 文件路径
+func (w *Client) AddCertPemFilePath(certFilePath, keyFilePath string) (err error) {
+	return w.addCertFileContentOrPath(certFilePath, keyFilePath, nil)
+}
+
+// 添加微信pkcs12证书文件路径
+//	pkcs12FilePath：apiclient_cert.p12 文件路径
+func (w *Client) AddCertPkcs12FilePath(pkcs12FilePath string) (err error) {
+	return w.addCertFileContentOrPath(nil, nil, pkcs12FilePath)
+}
+
+// 添加微信pem证书内容[]byte
+//	certFileContent：apiclient_cert.pem 证书内容[]byte
+//	keyFileContent：apiclient_key.pem 证书内容[]byte
+func (w *Client) AddCertPemFileContent(certFileContent, keyFileContent []byte) (err error) {
+	return w.addCertFileContentOrPath(certFileContent, keyFileContent, nil)
+}
+
+// 添加微信pkcs12证书内容[]byte
+//	p12FileContent：apiclient_cert.p12 证书内容[]byte
+func (w *Client) AddCertPkcs12FileContent(p12FileContent []byte) (err error) {
+	return w.addCertFileContentOrPath(nil, nil, p12FileContent)
+}
+
 // 添加微信证书文件 Path 路径或证书内容
 //	注意：只传pem证书或只传pkcs12证书均可，无需3个证书全传
-//	certFilePath：apiclient_cert.pem 路径或内容
-//	keyFilePath：apiclient_key.pem 路径或内容
-//	pkcs12FilePath：apiclient_cert.p12 路径或内容
-//	返回err
-func (w *Client) AddCertFilePath(certFilePath, keyFilePath, pkcs12FilePath interface{}) (err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+func (w *Client) addCertFileContentOrPath(certFile, keyFile, pkcs12File interface{}) (err error) {
+	if err = checkCertFilePathOrContent(certFile, keyFile, pkcs12File); err != nil {
 		return
 	}
 	var config *tls.Config
-	if config, err = w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
+	if config, err = w.addCertConfig(certFile, keyFile, pkcs12File); err != nil {
 		return
 	}
 	w.mu.Lock()
 	w.certificate = &config.Certificates[0]
 	w.mu.Unlock()
 	return
-}
-
-// Deprecated
-// 推荐使用 AddCertPemFileContent() 或 AddCertPkcs12FileContent()
-// 添加微信证书内容
-//	certFileContent：apiclient_cert.pem 内容
-//	keyFileContent：apiclient_key.pem 内容
-//	pkcs12FileContent：apiclient_cert.p12 内容
-//	返回err
-func (w *Client) AddCertFileContent(certFileContent, keyFileContent, pkcs12FileContent []byte) (err error) {
-	return w.AddCertFilePath(certFileContent, keyFileContent, pkcs12FileContent)
-}
-
-// 添加微信pem证书内容或证书文件Path
-func (w *Client) AddCertPemFileContent(certFileContent, keyFileContent []byte) (err error) {
-	return w.AddCertFilePath(certFileContent, keyFileContent, nil)
-}
-
-// 添加微信pkcs12证书内容证书文件Path
-func (w *Client) AddCertPkcs12FileContent(pkcs12FileContent []byte) (err error) {
-	return w.AddCertFilePath(nil, nil, pkcs12FileContent)
 }
 
 func (w *Client) addCertConfig(certFile, keyFile, pkcs12File interface{}) (tlsConfig *tls.Config, err error) {
@@ -95,7 +104,7 @@ func (w *Client) addCertConfig(certFile, keyFile, pkcs12File interface{}) (tlsCo
 			}
 			return tlsConfig, nil
 		}
-		return nil, errors.New("cert parse failed")
+		return nil, errors.New("cert parse failed or nil")
 	}
 
 	var (

--- a/wechat/red.go
+++ b/wechat/red.go
@@ -13,13 +13,11 @@ import (
 	"github.com/iGoogle-ink/gopay/pkg/util"
 )
 
-// SendCashRed 发放现金红包
+// 发放现金红包
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此处参数中的 wxappid 需要单独传参，不复用 NewClient 时的 appid，total_num = 1
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/tools/cash_coupon.php?chapter=13_4&index=3
-func (w *Client) SendCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *SendCashRedResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) SendCashRed(bm gopay.BodyMap) (wxRsp *SendCashRedResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "mch_billno", "wxappid", "send_name", "re_openid", "total_amount", "total_num", "wishing", "client_ip", "act_name", "remark")
 	if err != nil {
 		return nil, err
@@ -35,7 +33,7 @@ func (w *Client) SendCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12
 		bm.Set("sign", sign)
 	}
 
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -51,13 +49,11 @@ func (w *Client) SendCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12
 	return wxRsp, nil
 }
 
-// SendGroupCashRed 发放现金裂变红包
+// 发放现金裂变红包
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此处参数中的 wxappid 需要单独传参，不复用 NewClient 时的 appid，amt_type = ALL_RAND
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/tools/cash_coupon.php?chapter=13_5&index=4
-func (w *Client) SendGroupCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *SendCashRedResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) SendGroupCashRed(bm gopay.BodyMap) (wxRsp *SendCashRedResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "mch_billno", "wxappid", "send_name", "re_openid", "total_amount", "total_num", "amt_type", "wishing", "act_name", "remark")
 	if err != nil {
 		return nil, err
@@ -74,7 +70,7 @@ func (w *Client) SendGroupCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, p
 		bm.Set("sign", sign)
 	}
 
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -90,13 +86,11 @@ func (w *Client) SendGroupCashRed(bm gopay.BodyMap, certFilePath, keyFilePath, p
 	return wxRsp, nil
 }
 
-// SendAppletRed 发放小程序红包
+// 发放小程序红包
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此处参数中的 wxappid 需要单独传参，不复用 NewClient 时的 appid，total_num = 1，notify_way = MINI_PROGRAM_JSAPI
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/tools/cash_coupon.php?chapter=18_2&index=3
-func (w *Client) SendAppletRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *SendAppletRedResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) SendAppletRed(bm gopay.BodyMap) (wxRsp *SendAppletRedResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "mch_billno", "wxappid", "send_name", "re_openid", "total_amount", "total_num", "wishing", "act_name", "remark", "notify_way")
 	if err != nil {
 		return nil, err
@@ -113,7 +107,7 @@ func (w *Client) SendAppletRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs
 		bm.Set("sign", sign)
 	}
 
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -129,13 +123,11 @@ func (w *Client) SendAppletRed(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs
 	return wxRsp, nil
 }
 
-// QueryRedRecord 查询红包记录
+// 查询红包记录
+//	注意：请在初始化client时，调用 client 添加证书的相关方法添加证书
 //	注意：此处参数中的 appid 需要单独传参，不复用 NewClient 时的 appid，bill_type = MCHT
 //	微信文档：https://pay.weixin.qq.com/wiki/doc/api/tools/cash_coupon.php?chapter=13_6&index=5
-func (w *Client) QueryRedRecord(bm gopay.BodyMap, certFilePath, keyFilePath, pkcs12FilePath interface{}) (wxRsp *QueryRedRecordResponse, err error) {
-	if err = checkCertFilePathOrContent(certFilePath, keyFilePath, pkcs12FilePath); err != nil {
-		return nil, err
-	}
+func (w *Client) QueryRedRecord(bm gopay.BodyMap) (wxRsp *QueryRedRecordResponse, err error) {
 	err = bm.CheckEmptyError("nonce_str", "mch_billno", "appid", "bill_type")
 	if err != nil {
 		return nil, err
@@ -152,7 +144,7 @@ func (w *Client) QueryRedRecord(bm gopay.BodyMap, certFilePath, keyFilePath, pkc
 		bm.Set("sign", sign)
 	}
 
-	tlsConfig, err := w.addCertConfig(certFilePath, keyFilePath, pkcs12FilePath)
+	tlsConfig, err := w.addCertConfig(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
版本号：Release 1.5.38
修改记录：
   (1) 微信：去掉所以微信 client 方法中需要传证书的参数，请统一在初始化client时，添加证书
   (2) 微信：使用方法请参考 wechat/client_test.go 下的初始化，以及各个方法使用